### PR TITLE
Cli was overly complex

### DIFF
--- a/examples/Example.WebApi/README.md
+++ b/examples/Example.WebApi/README.md
@@ -303,8 +303,8 @@ To decrypt the production logs, you can use the CLI tool:
 # The log file name will include the date (e.g., prod20251129.txt)
 serilog-encrypt decrypt logs/prod20251129.txt -k private_key.xml
 
-# Or decrypt all production logs in the directory
-serilog-encrypt decrypt logs/ -k private_key.xml -p "prod*.txt"
+# Or decrypt all production logs using a glob pattern
+serilog-encrypt decrypt "logs/prod*.txt" -k private_key.xml
 ```
 
 **Note**: You will need the private key file (`private_key.xml`) that was generated earlier with the `serilog-encrypt generate` command.

--- a/resources/nuget/Serilog.Sinks.File.Encrypt.md
+++ b/resources/nuget/Serilog.Sinks.File.Encrypt.md
@@ -9,7 +9,7 @@
 A [Serilog.File.Sink](https://github.com/serilog/serilog-sinks-file) hook that encrypts log files using RSA and AES encryption. This package provides secure logging by encrypting log data before writing to disk, ensuring sensitive information remains protected.
 
 > [!Note]
-> :construction: **Early release Software** :construction:
+> :construction: **Newly Released** :construction:
 > This library is newly released. APIs may change in future versions. Please report any issues you encounter or suggestions for improvement.
  
 ## Features

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
@@ -43,8 +43,11 @@ public static class CommandAppConfiguration
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey)
                 .WithExample(Decrypt, "./logs", "-k", PrivateKey)
                 .WithExample(Decrypt, "*.log", "-k", PrivateKey)
+                .WithExample(Decrypt, "logs/*.txt", "-k", PrivateKey)
                 .WithExample(Decrypt, "./logs", "-k", PrivateKey, "-r")
-                .WithExample(Decrypt, "app.log", "-k", PrivateKey, "-o", "decrypted.log");
+                .WithExample(Decrypt, "app.log", "-k", PrivateKey, "-o", "decrypted.log")
+                .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--strict")
+                .WithExample(Decrypt, "./logs", "-k", PrivateKey, "--error-log", "errors.log");
             c.ValidateExamples();
         };
     }

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Usings.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Usings.cs
@@ -4,7 +4,6 @@ global using System.Security.Cryptography;
 global using System.Text;
 global using NSubstitute;
 global using Serilog.Sinks.File.Encrypt.Cli.Commands;
-global using Serilog.Sinks.File.Encrypt.Models;
 global using Shouldly;
 global using Spectre.Console.Cli;
 global using Spectre.Console.Testing;


### PR DESCRIPTION
## Summary
Simplified the decrypt command to make it easier to use and script by reducing the number of options and consolidating related functionality.

## Breaking Changes

### Removed Command Options
1. **`-p|--pattern <PATTERN>`** - Removed
   - **Before**: `serilog-encrypt decrypt ./logs -k key.xml -p "app*.log"`
   - **After**: `serilog-encrypt decrypt "logs/app*.log" -k key.xml`
   - **Reason**: Pattern is now inferred from the input path. Directories automatically use `*.log` pattern.

2. **`-e|--error-mode <MODE>`** - Removed
   - **Before**: Had 4 modes (Skip, WriteInline, WriteToErrorLog, ThrowException)
   - **After**: Replaced with simpler `--strict` flag
   - **Reason**: Simplified error handling to two practical modes: continue on errors (default) or fail fast (strict)

3. **`--continue-on-error`** - Removed
   - **Before**: `--continue-on-error true/false`
   - **After**: Use `--strict` flag to fail on first error
   - **Reason**: Consolidated into `--strict` flag for simpler usage

### New/Modified Command Options

1. **`-s|--strict`** - New flag
   - **Usage**: `serilog-encrypt decrypt app.log -k key.xml --strict`
   - **Behavior**: Fails immediately on first decryption error
   - **Default**: false (continues processing all files)

2. **`--error-log <PATH>`** - Simplified
   - **Before**: Only worked with `-e WriteToErrorLog` mode
   - **After**: Works independently to log detailed errors
   - **Usage**: `serilog-encrypt decrypt ./logs -k key.xml --error-log errors.log`

3. **`<PATH>` argument** - Enhanced
   - **Single file**: `decrypt app.log -k key.xml`
   - **Directory**: `decrypt ./logs -k key.xml` (uses `*.log` pattern automatically)
   - **Glob pattern**: `decrypt "logs/app*.txt" -k key.xml`
   - **Recursive**: `decrypt ./logs -k key.xml -r`
