### PR TITLE
feat: Switch to stream cypher

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -135,8 +135,8 @@ Key rotation is essential for long-term security:
 
 This library uses the .NET cryptographic libraries (`System.Security.Cryptography`) and relies on:
 
-- **RSA-OAEP-SHA256**: For encrypting AES keys and IVs
-- **AES-256-CBC**: For log content encryption with PKCS7 padding
+- **RSA-OAEP-SHA256**: For encrypting AES keys and nonce
+- **AES-256-GCM**: For log content encryption
 
 We monitor dependencies through:
 - GitHub Dependabot (automated PRs for dependency updates)

--- a/src/Serilog.Sinks.File.Encrypt/EncryptedStream.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptedStream.cs
@@ -3,18 +3,17 @@ using System.Security.Cryptography;
 namespace Serilog.Sinks.File.Encrypt;
 
 /// <summary>
-/// Encrypts data written to the underlying stream using hybrid AES-256 + RSA encryption.
+/// Encrypts data written to the underlying stream using hybrid AES-256 GCM + RSA encryption.
 /// </summary>
 /// <remarks>
 /// <para>
 /// This stream wraps an underlying stream and encrypts all data written to it using a hybrid encryption scheme:
-/// - AES-256 is used for data encryption (symmetric, fast)
-/// - RSA is used to encrypt the AES key and IV (asymmetric, secure key exchange)
+/// - AES-256 GCM is used for data encryption (symmetric, fast)
+/// - RSA is used to encrypt the AES key and nonce (asymmetric, secure key exchange)
 /// </para>
 /// <para>
 /// <b>Memory Usage:</b> Each call to <see cref="Flush"/> or <see cref="FlushAsync"/> creates a new encryption chunk.
-/// Data is buffered in memory until flushed. Typical chunk sizes range from 1KB to 64KB depending on logging patterns.
-/// The internal buffer is released after each flush operation.
+/// A chunk consists of one RSA header (symmetric AES key) and multiple AES-encrypted data blocks.
 /// </para>
 /// <para>
 /// <b>Thread Safety:</b> This class is NOT thread-safe. It is designed to be used by Serilog.Sinks.File
@@ -37,18 +36,24 @@ namespace Serilog.Sinks.File.Encrypt;
 public class EncryptedStream : Stream
 {
     // csharpier-ignore-start
-    private static readonly byte[] _headerMarker = [ 0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01 ];
-    private static readonly byte[] _chunkMarker =  [ 0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x42, 0x44, 0x00, 0x02 ];
+    private static readonly byte[] _marker = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01];
+    private static readonly byte _escapeMarker = 0x00;
     // csharpier-ignore-end
 
+    // length of the nonce in bytes (counter for the stream cypher)
+    private const int NONCE_LENGTH = 12;
+    // length of the AES session key in bytes
+    private const int SESSION_KEY_LENGTH = 32; // 256 bit
+    // tag (hmac) to confirm data integrity
+    private const int TAG_LENGTH = 12; // 96 bit
+
     private readonly Stream _underlyingStream;
-    private readonly ICryptoTransform _currentCryptoTransform;
-    private readonly Aes _aes;
+    private readonly RSA _rsaPublicKey;
+
+    private AesGcm? _aes;
 
     private bool _isDisposed;
-    private bool _needsNewChunk = true;
-    private MemoryStream? _bufferStream;
-    private CryptoStream? _currentCryptoStream;
+    private byte[] _nonce = [0];
 
     /// <summary>
     /// Creates a new instance of <see cref="EncryptedStream"/> that encrypts data written to the underlying stream.
@@ -63,96 +68,68 @@ public class EncryptedStream : Stream
     /// </remarks>
     public EncryptedStream(Stream underlyingStream, RSA rsaPublicKey)
     {
+        ArgumentNullException.ThrowIfNull(underlyingStream);
+        ArgumentNullException.ThrowIfNull(rsaPublicKey);
+
         _underlyingStream = underlyingStream;
-
-        // Generate a new random key and IV for this stream
-        _aes = Aes.Create();
-        byte[] currentKey = _aes.Key;
-        byte[] currentIv = _aes.IV;
-        _aes.Padding = PaddingMode.PKCS7;
-        _currentCryptoTransform = _aes.CreateEncryptor(currentKey, currentIv);
-
-        byte[] encryptedKey = rsaPublicKey.Encrypt(currentKey, RSAEncryptionPadding.OaepSHA256);
-        byte[] encryptedKeyLength = BitConverter.GetBytes(encryptedKey.Length);
-        byte[] encryptedIv = rsaPublicKey.Encrypt(currentIv, RSAEncryptionPadding.OaepSHA256);
-        byte[] encryptedIvLength = BitConverter.GetBytes(encryptedIv.Length);
-        _underlyingStream.Write(_headerMarker, 0, _headerMarker.Length);
-        _underlyingStream.Write(encryptedKeyLength, 0, sizeof(int));
-        _underlyingStream.Write(encryptedIvLength, 0, sizeof(int));
-        _underlyingStream.Write(encryptedKey, 0, encryptedKey.Length);
-        _underlyingStream.Write(encryptedIv, 0, encryptedIv.Length);
+        _rsaPublicKey = rsaPublicKey;
     }
 
     private void StartNewEncryptionChunk()
     {
-        // Create a memory buffer to hold the encrypted content
-        _bufferStream = new MemoryStream();
-        _currentCryptoStream = new CryptoStream(
-            _bufferStream,
-            _currentCryptoTransform,
-            CryptoStreamMode.Write,
-            leaveOpen: true
-        );
+        byte[] sessionKey = new byte[SESSION_KEY_LENGTH];
+        _nonce = new byte[NONCE_LENGTH];
+
+        RandomNumberGenerator.Fill(sessionKey);
+        RandomNumberGenerator.Fill(_nonce);
+
+        _aes = new AesGcm(sessionKey, TAG_LENGTH);
+
+        byte[] encryptedTagSize = _rsaPublicKey.Encrypt(BitConverter.GetBytes(TAG_LENGTH), RSAEncryptionPadding.OaepSHA256);
+        byte[] encryptedNonce = _rsaPublicKey.Encrypt(_nonce, RSAEncryptionPadding.OaepSHA256);
+        byte[] encryptedSessionKey = _rsaPublicKey.Encrypt(sessionKey, RSAEncryptionPadding.OaepSHA256);
+
+        byte[] encryptedTagSizeLength = BitConverter.GetBytes(encryptedTagSize.Length);
+        byte[] encryptedNonceLength = BitConverter.GetBytes(encryptedNonce.Length);
+        byte[] encryptedSessionKeyLength = BitConverter.GetBytes(encryptedSessionKey.Length);
+
+        byte[] messageHeader = [
+            ..encryptedTagSize,
+            ..encryptedNonce,
+            ..encryptedSessionKey];
+
+        messageHeader.Escape(_marker, _escapeMarker);
+
+        _underlyingStream.Write(_marker);
+        _underlyingStream.Write(encryptedTagSizeLength);
+        _underlyingStream.Write(encryptedNonceLength);
+        _underlyingStream.Write(encryptedSessionKeyLength);
+        _underlyingStream.Write(messageHeader);
     }
 
     /// <inheritdoc/>
     public override void Flush()
     {
-        if (_currentCryptoStream != null && _bufferStream != null)
+        if (_aes != null)
         {
-            // Finalize the encryption
-            _currentCryptoStream.FlushFinalBlock();
-            _currentCryptoStream.Dispose();
-            _currentCryptoStream = null;
+            _underlyingStream.Flush();
 
-            // Get the encrypted data from the buffer
-            byte[] encryptedData = _bufferStream.ToArray();
-            _bufferStream.Dispose();
-            _bufferStream = null;
-
-            // Write the complete chunk: [MARKER][LENGTH][ENCRYPTED_DATA]
-            _underlyingStream.Write(_chunkMarker, 0, _chunkMarker.Length);
-            byte[] lengthBytes = BitConverter.GetBytes(encryptedData.Length);
-            _underlyingStream.Write(lengthBytes, 0, sizeof(int));
-            _underlyingStream.Write(encryptedData, 0, encryptedData.Length);
-
-            _needsNewChunk = true;
+            _aes.Dispose();
+            _aes = null;
         }
-        _underlyingStream.Flush();
     }
 
     /// <inheritdoc/>
     public override async Task FlushAsync(CancellationToken cancellationToken)
     {
-        if (_currentCryptoStream != null && _bufferStream != null)
+        if (_aes != null)
         {
-            // Finalize the encryption
-            await _currentCryptoStream
-                .FlushFinalBlockAsync(cancellationToken)
-                .ConfigureAwait(false);
-            await _currentCryptoStream.DisposeAsync().ConfigureAwait(false);
-            _currentCryptoStream = null;
-
-            // Get the encrypted data from the buffer
-            byte[] encryptedData = _bufferStream.ToArray();
-            await _bufferStream.DisposeAsync().ConfigureAwait(false);
-            _bufferStream = null;
-
-            // Write the complete chunk: [MARKER][LENGTH][ENCRYPTED_DATA]
-            await _underlyingStream
-                .WriteAsync(_chunkMarker, cancellationToken)
-                .ConfigureAwait(false);
-            byte[] lengthBytes = BitConverter.GetBytes(encryptedData.Length);
-            await _underlyingStream
-                .WriteAsync(lengthBytes.AsMemory(0, sizeof(int)), cancellationToken)
-                .ConfigureAwait(false);
-            await _underlyingStream
-                .WriteAsync(encryptedData, cancellationToken)
+            await _underlyingStream.FlushAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            _needsNewChunk = true;
+            _aes.Dispose();
+            _aes = null;
         }
-        await _underlyingStream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -193,14 +170,7 @@ public class EncryptedStream : Stream
     /// <inheritdoc/>
     public override void Write(byte[] buffer, int offset, int count)
     {
-        ObjectDisposedException.ThrowIf(_isDisposed, this);
-
-        if (_needsNewChunk || _currentCryptoStream == null)
-        {
-            StartNewEncryptionChunk();
-            _needsNewChunk = false;
-        }
-        _currentCryptoStream?.Write(buffer, offset, count);
+        Write(buffer[offset..(offset + count)].AsSpan());
     }
 
     /// <inheritdoc/>
@@ -208,12 +178,12 @@ public class EncryptedStream : Stream
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
 
-        if (_needsNewChunk || _currentCryptoStream == null)
+        if (_aes == null)
         {
             StartNewEncryptionChunk();
-            _needsNewChunk = false;
         }
-        _currentCryptoStream?.Write(buffer);
+
+        _underlyingStream.Write(Transform(buffer));
     }
 
     /// <inheritdoc/>
@@ -223,16 +193,16 @@ public class EncryptedStream : Stream
     )
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
-        if (_needsNewChunk || _currentCryptoStream == null)
+
+        if (_aes == null)
         {
             StartNewEncryptionChunk();
-            _needsNewChunk = false;
         }
 
-        if (_currentCryptoStream != null)
-        {
-            await _currentCryptoStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
-        }
+        await _underlyingStream.WriteAsync(
+            Transform(buffer.Span),
+            cancellationToken
+        ).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -270,7 +240,7 @@ public class EncryptedStream : Stream
         if (disposing)
         {
             // Flush any remaining data before disposing
-            if (_currentCryptoStream != null || _bufferStream != null)
+            if (_aes != null)
             {
                 try
                 {
@@ -290,12 +260,26 @@ public class EncryptedStream : Stream
                 }
             }
 
-            _currentCryptoStream?.Dispose();
-            _bufferStream?.Dispose();
             _underlyingStream.Dispose();
-            _currentCryptoTransform.Dispose();
-            _aes.Dispose();
         }
+
         base.Dispose(disposing);
+    }
+
+    private byte[] Transform(ReadOnlySpan<byte> plainText)
+    {
+        byte[] cypherText = new byte[plainText.Length];
+        byte[] hmac = new byte[TAG_LENGTH];
+
+        _aes!.Encrypt(_nonce, plainText, cypherText, hmac);
+
+        // increase the nonce for next block
+        _nonce.IncreaseNonce();
+
+        // concat and escape message data
+        byte[] message = [.. cypherText, .. hmac];
+        message.Escape(_marker, _escapeMarker);
+
+        return [.. BitConverter.GetBytes(message.Length), .. message];
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt/EncryptedStream.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptedStream.cs
@@ -110,26 +110,14 @@ public class EncryptedStream : Stream
     /// <inheritdoc/>
     public override void Flush()
     {
-        if (_aes != null)
-        {
-            _underlyingStream.Flush();
-
-            _aes.Dispose();
-            _aes = null;
-        }
+        _underlyingStream.Flush();
     }
 
     /// <inheritdoc/>
     public override async Task FlushAsync(CancellationToken cancellationToken)
     {
-        if (_aes != null)
-        {
-            await _underlyingStream.FlushAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            _aes.Dispose();
-            _aes = null;
-        }
+        await _underlyingStream.FlushAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.File.Encrypt/EncryptionUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptionUtils.cs
@@ -30,67 +30,6 @@ namespace Serilog.Sinks.File.Encrypt;
 public static class EncryptionUtils
 {
     /// <summary>
-    /// Escapes occurrences of the specified marker in the data by inserting an escape byte after each occurrence.
-    /// </summary>
-    /// <param name="data">The data to escape.</param>
-    /// <param name="marker">The marker to search for.</param>
-    /// <param name="escapeMarker">The escape marker to insert for each found <paramref name="marker"/> within <paramref name="data"/>.</param>
-    /// <returns>Inplace modified <paramref name="data"/> with escaped markers.</returns>
-    internal static byte[] Escape(this byte[] data, byte[] marker, byte escapeMarker)
-    {
-        while (true)
-        {
-            int pos = data.IndexOf(marker);
-
-            if (pos != -1)
-            {
-                Array.Resize(ref data, data.Length + 1);
-                Array.Copy(data, pos + 1, data, pos + 2, data.Length - (pos + 2));
-                data[pos + 1] = escapeMarker;
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        return data;
-    }
-
-    /// <summary>
-    /// Unescapes occurrences of the specified marker in the data by removing the escape byte after each occurrence.
-    /// </summary>
-    /// <param name="data">The data to unescape.</param>
-    /// <param name="marker">The marker to search for.</param>
-    /// <param name="escapeMarker">The escape marker to remove.</param>
-    /// <returns>Inplace modified <paramref name="data"/> with unescaped markers.</returns>
-    internal static byte[] Unescape(this byte[] data, byte[] marker, byte escapeMarker)
-    {
-        byte[] markerWithEscape = new byte[marker.Length + 1];
-
-        markerWithEscape[0] = marker[0];
-        markerWithEscape[1] = escapeMarker;
-        Array.Copy(marker, 1, markerWithEscape, 2, marker.Length - 1);
-
-        while (true)
-        {
-            int pos = data.IndexOf(markerWithEscape);
-
-            if (pos != -1)
-            {
-                Array.Copy(data, pos + 2, data, pos + 1, data.Length - (pos + 2));
-                Array.Resize(ref data, data.Length - 1);
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        return data;
-    }
-
-    /// <summary>
     /// AES-GCM encryption requires a unique nonce for each encryption operation.
     /// This method retrieves the current nonce value stored in the last 8 bytes of the data array.
     /// </summary>

--- a/src/Serilog.Sinks.File.Encrypt/Models/DecryptionContext.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Models/DecryptionContext.cs
@@ -3,8 +3,22 @@ namespace Serilog.Sinks.File.Encrypt.Models;
 /// <summary>
 /// Represents the current decryption context with active encryption keys
 /// </summary>
-internal record DecryptionContext(byte[] Key, byte[] Iv)
+internal class DecryptionContext
 {
-    public static DecryptionContext Empty => new([], []);
-    public bool HasKeys => Key.Length > 0 && Iv.Length > 0;
+    public DecryptionContext(int tagLength, byte[] nonce, byte[] sessionKey)
+    {
+        Nonce = nonce;
+        SessionKey = sessionKey;
+        TagLength = tagLength;
+    }
+
+    public int TagLength { get; init; }
+
+    public byte[] SessionKey { get; init; }
+
+    public byte[] Nonce { get; private set; }
+
+    public static DecryptionContext Empty => new(0, [], []);
+
+    public bool HasKeys => Nonce.Length > 0 && SessionKey.Length > 0 && TagLength > 0;
 }

--- a/src/Serilog.Sinks.File.Encrypt/Models/HeaderSection.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Models/HeaderSection.cs
@@ -3,4 +3,4 @@ namespace Serilog.Sinks.File.Encrypt.Models;
 /// <summary>
 /// Represents a parsed header section from the encrypted file
 /// </summary>
-internal record HeaderSection(byte[] EncryptedKey, byte[] EncryptedIv);
+internal record HeaderSection(byte[] TagLength, byte[] Nonce, byte[] SessionKey);

--- a/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
+++ b/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
@@ -181,7 +181,7 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
 
         if (IsHeaderMarker(markerBuffer))
         {
-            await ProcessHeaderSectionAsync(markerBuffer, cancellationToken);
+            await ProcessHeaderSectionAsync(cancellationToken);
         }
         else if (_context.HasKeys)
         {
@@ -199,7 +199,6 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// Processes a header section to extract encryption keys
     /// </summary>
     private async Task ProcessHeaderSectionAsync(
-        byte[] markerBuffer,
         CancellationToken cancellationToken
     )
     {

--- a/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
+++ b/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
@@ -11,10 +11,10 @@ namespace Serilog.Sinks.File.Encrypt;
 internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposable
 {
     // csharpier-ignore-start
-    private static readonly byte[] _headerMarker = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01];
-    private static readonly byte[] _messageMarker = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x42, 0x44, 0x00, 0x02];
+    private static readonly byte[] _marker = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01];
+    private static readonly byte _escapeMarker = 0x00;
     // csharpier-ignore-end
-    private static readonly int _markerLength = _headerMarker.Length;
+    private static readonly int _markerLength = _marker.Length;
 
     private readonly Stream _inputStream;
     private readonly RSA _rsa;
@@ -173,6 +173,7 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     )
     {
         byte[]? markerBuffer = await ReadMarkerBufferAsync(cancellationToken);
+
         if (markerBuffer == null)
         {
             return;
@@ -182,13 +183,15 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
         {
             await ProcessHeaderSectionAsync(markerBuffer, cancellationToken);
         }
-        else if (IsBodyMarker(markerBuffer))
+        else if (_context.HasKeys)
         {
             await ProcessBodySectionAsync(writer, cancellationToken);
         }
         else
         {
-            SkipUnknownData(markerBuffer);
+            // move the stream position forward by 1 byte to continue searching
+            // for the first valid header marker
+            _inputStream.Position += 1;
         }
     }
 
@@ -200,15 +203,7 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
         CancellationToken cancellationToken
     )
     {
-        long markerPosition = _inputStream.Position - markerBuffer.Length;
-
-        if (!await IsValidHeaderAsync(markerPosition, cancellationToken))
-        {
-            SkipUnknownData(markerBuffer);
-            return;
-        }
-
-        HeaderSection header = await ReadHeaderSectionAsync(markerPosition, cancellationToken);
+        HeaderSection header = await ReadHeaderSectionAsync(cancellationToken);
 
         // Mark that we found a valid header marker (before attempting decryption)
         // This way, if decryption fails with wrong key, we get a proper crypto error
@@ -226,12 +221,8 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
         CancellationToken cancellationToken
     )
     {
-        if (!_context.HasKeys)
-        {
-            return;
-        }
-
         MessageSection body = await ReadMessageSectionAsync(cancellationToken);
+
         string decryptedText = await DecryptMessageContentAsync(
             body.MessageLength,
             cancellationToken
@@ -243,28 +234,33 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// Reads header section data from the input stream
     /// </summary>
     private async Task<HeaderSection> ReadHeaderSectionAsync(
-        long markerPosition,
         CancellationToken cancellationToken
     )
     {
-        _inputStream.Position = markerPosition + _markerLength;
+        // skip the header marker
+        _inputStream.Position += _markerLength;
 
-        // Read key and IV lengths
-        byte[] keyLengthBytes = new byte[4];
-        byte[] ivLengthBytes = new byte[4];
-        await _inputStream.ReadExactlyAsync(keyLengthBytes, cancellationToken);
-        await _inputStream.ReadExactlyAsync(ivLengthBytes, cancellationToken);
+        // Read the tag, nonce, and session key lengths
+        byte[] tagLengthBytes = new byte[sizeof(int)];
+        byte[] nonceLengthBytes = new byte[sizeof(int)];
+        byte[] sessionKeyLengthBytes = new byte[sizeof(int)];
+        await _inputStream.ReadExactlyAsync(tagLengthBytes, cancellationToken);
+        await _inputStream.ReadExactlyAsync(nonceLengthBytes, cancellationToken);
+        await _inputStream.ReadExactlyAsync(sessionKeyLengthBytes, cancellationToken);
 
-        int keyLength = BitConverter.ToInt32(keyLengthBytes, 0);
-        int ivLength = BitConverter.ToInt32(ivLengthBytes, 0);
+        int tagBytesLength = BitConverter.ToInt32(tagLengthBytes, 0);
+        int nonceLength = BitConverter.ToInt32(nonceLengthBytes, 0);
+        int sessionKeyLength = BitConverter.ToInt32(sessionKeyLengthBytes, 0);
 
-        // Read encrypted key and IV
-        byte[] encryptedKey = new byte[keyLength];
-        byte[] encryptedIv = new byte[ivLength];
-        await _inputStream.ReadExactlyAsync(encryptedKey, cancellationToken);
-        await _inputStream.ReadExactlyAsync(encryptedIv, cancellationToken);
+        byte[] headerSection = new byte[tagBytesLength + nonceLength + sessionKeyLength];
 
-        return new HeaderSection(encryptedKey, encryptedIv);
+        await _inputStream.ReadExactlyAsync(headerSection, cancellationToken);
+
+        headerSection.Unescape(_marker, _escapeMarker);
+
+        return new HeaderSection(headerSection[..tagBytesLength],
+            headerSection[tagBytesLength..^nonceLength],
+            headerSection[^sessionKeyLength..]);
     }
 
     /// <summary>
@@ -283,68 +279,56 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// </summary>
     private DecryptionContext DecryptKeys(HeaderSection header)
     {
-        byte[] key = _rsa.Decrypt(header.EncryptedKey, RSAEncryptionPadding.OaepSHA256);
-        byte[] iv = _rsa.Decrypt(header.EncryptedIv, RSAEncryptionPadding.OaepSHA256);
-        return new DecryptionContext(key, iv);
+        byte[] tagLengthBytes = _rsa.Decrypt(header.TagLength, RSAEncryptionPadding.OaepSHA256);
+        byte[] nonce = _rsa.Decrypt(header.Nonce, RSAEncryptionPadding.OaepSHA256);
+        byte[] sessionkey = _rsa.Decrypt(header.SessionKey, RSAEncryptionPadding.OaepSHA256);
+
+        int tag = BitConverter.ToInt32(tagLengthBytes);
+
+        return new DecryptionContext(tag, nonce, sessionkey);
     }
 
     /// <summary>
     /// Decrypts message content from the input stream using streaming
     /// </summary>
     private async Task<string> DecryptMessageContentAsync(
-        int dataLength,
+        int messageLength,
         CancellationToken cancellationToken
     )
     {
-        ValidateMessageSize(dataLength);
+        byte[] message = new byte[messageLength];
+        await _inputStream.ReadExactlyAsync(message, cancellationToken);
+        message.Unescape(_marker, _escapeMarker);
 
-        byte[] encryptedData = new byte[dataLength];
-        await _inputStream.ReadExactlyAsync(encryptedData, cancellationToken);
+        byte[] cypherText = message[..^_context.TagLength];
+        byte[] hmac = message[^_context.TagLength..];
 
-        return await DecryptDataAsync(encryptedData, _context.Key, _context.Iv, cancellationToken);
-    }
+        string plainText = DecryptData(cypherText, _context.SessionKey, _context.Nonce, hmac, _context.TagLength);
 
-    /// <summary>
-    /// Validates that the message size is reasonable
-    /// </summary>
-    private static void ValidateMessageSize(int dataLength)
-    {
-        const int MaxLogMessageSize = 10_000_000; // 10 MB should be more than enough for any single log message
-        if (dataLength > MaxLogMessageSize)
-        {
-            throw new InvalidOperationException(
-                $"Log message size ({dataLength} bytes) is unexpectedly large (>{MaxLogMessageSize} bytes). This may indicate file corruption."
-            );
-        }
+        _context.Nonce.IncreaseNonce();
+
+        return plainText;
     }
 
     /// <summary>
     /// Decrypts data using AES with the provided key and IV using streaming approach
     /// </summary>
-    private static async Task<string> DecryptDataAsync(
-        byte[] encryptedData,
-        byte[] key,
-        byte[] iv,
-        CancellationToken cancellationToken
+    private static string DecryptData(
+        byte[] cypherText,
+        byte[] sessionKey,
+        byte[] nonce,
+        byte[] hmac,
+        int tagLength
     )
     {
-        using Aes aes = Aes.Create();
-        aes.Key = key;
-        aes.IV = iv;
-        aes.Padding = PaddingMode.PKCS7;
+        using AesGcm aes = new AesGcm(sessionKey, tagLength);
+        using MemoryStream memoryStream = new();
 
-        using ICryptoTransform decryptor = aes.CreateDecryptor();
-        await using MemoryStream memoryStream = new();
-        await using CryptoStream cryptoStream = new(
-            memoryStream,
-            decryptor,
-            CryptoStreamMode.Write
-        );
+        byte[] plainText = new byte[cypherText.Length];
 
-        await cryptoStream.WriteAsync(encryptedData, cancellationToken);
-        await cryptoStream.FlushFinalBlockAsync(cancellationToken);
+        aes.Decrypt(nonce, cypherText, hmac, plainText);
 
-        return Encoding.UTF8.GetString(memoryStream.ToArray());
+        return Encoding.UTF8.GetString(plainText);
     }
 
     /// <summary>
@@ -463,19 +447,14 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     {
         byte[] markerBuffer = new byte[_markerLength];
         int bytesRead = await _inputStream.ReadAsync(markerBuffer, cancellationToken);
-        return bytesRead == markerBuffer.Length ? markerBuffer : null;
+        _inputStream.Position -= bytesRead != _markerLength ? 0 : _markerLength;
+        return bytesRead == _markerLength ? markerBuffer : null;
     }
 
     private bool IsEndOfStream() => _inputStream.Position >= _inputStream.Length;
 
     private static bool IsHeaderMarker(byte[] markerBuffer) =>
-        markerBuffer.SequenceEqual(_headerMarker);
-
-    private static bool IsBodyMarker(byte[] markerBuffer) =>
-        markerBuffer.SequenceEqual(_messageMarker);
-
-    private void SkipUnknownData(byte[] markerBuffer) =>
-        _inputStream.Position -= markerBuffer.Length - 1;
+        markerBuffer.SequenceEqual(_marker);
 
     private async Task HandleErrorAsync(
         ChannelWriter<IDecryptionChunk> writer,
@@ -507,7 +486,7 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
             }
 
             // Check if it's a valid marker
-            if (IsHeaderMarker(searchBuffer) || IsBodyMarker(searchBuffer))
+            if (IsHeaderMarker(searchBuffer))
             {
                 // Move back to start of marker
                 _inputStream.Position -= _markerLength;
@@ -516,66 +495,6 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
 
             // Move back and advance by 1 byte to continue searching
             _inputStream.Position -= _markerLength - 1;
-        }
-    }
-
-    /// <summary>
-    /// Validates that a potential header marker is followed by reasonable key/IV length values
-    /// </summary>
-    private async Task<bool> IsValidHeaderAsync(
-        long markerPosition,
-        CancellationToken cancellationToken
-    )
-    {
-        long originalPosition = _inputStream.Position;
-        try
-        {
-            _inputStream.Position = markerPosition + _markerLength;
-
-            byte[] keyLengthBytes = new byte[4];
-            byte[] ivLengthBytes = new byte[4];
-
-            if (
-                await _inputStream.ReadAsync(keyLengthBytes, cancellationToken) != 4
-                || await _inputStream.ReadAsync(ivLengthBytes, cancellationToken) != 4
-            )
-            {
-                return false;
-            }
-
-            int keyLength = BitConverter.ToInt32(keyLengthBytes, 0);
-            int ivLength = BitConverter.ToInt32(ivLengthBytes, 0);
-
-            // Validate the lengths are reasonable for RSA encrypted AES keys/IVs
-            const int MinKeyIvLength = 256;
-            const int MaxKeyIvLength = 4096;
-            return keyLength is >= MinKeyIvLength and <= MaxKeyIvLength
-                && ivLength is >= MinKeyIvLength and <= MaxKeyIvLength;
-        }
-        catch (IOException)
-        {
-            // Stream read error - invalid header
-            return false;
-        }
-        catch (NotSupportedException)
-        {
-            // Stream doesn't support seeking/positioning - invalid header
-            return false;
-        }
-        catch (ObjectDisposedException)
-        {
-            // Stream was disposed - invalid header
-            return false;
-        }
-        catch (ArgumentException)
-        {
-            // Invalid position or BitConverter argument - invalid header
-            return false;
-        }
-        finally
-        {
-            // Restore original position so calling code can read the header data
-            _inputStream.Position = originalPosition;
         }
     }
 

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
@@ -82,7 +82,6 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
-        // Corrupt the second message part
         byte[] corrupted = CorruptData(fileBytes, fileBytes.Length / 2);
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 
@@ -116,7 +115,6 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
-        // Corrupt the second message part
         byte[] corrupted = CorruptData(fileBytes, fileBytes.Length / 2);
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
@@ -198,6 +198,9 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             TestContext.Current.CancellationToken
         );
 
+        // Assert
+        result.ShouldBeEmpty();
+
         // Error log file should exist (in real file system for this test)
         string fileContents = await System.IO.File.ReadAllTextAsync(
             errorLogPath,

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
@@ -82,6 +82,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
+        // Corrupt the second message part
         byte[] corrupted = CorruptData(fileBytes, fileBytes.Length / 2);
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 
@@ -93,7 +94,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         );
 
         // Assert
-        result.ShouldBeEmpty();
+        result.ShouldBe("Good message 1");
     }
 
     [Fact]
@@ -115,6 +116,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
+        // Corrupt the second message part
         byte[] corrupted = CorruptData(fileBytes, fileBytes.Length / 2);
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 
@@ -127,7 +129,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         );
 
         // Assert
-        result.ShouldBeEmpty();
+        result.ShouldBe("Good message 1");
     }
 
     [Fact]
@@ -195,9 +197,6 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             errorLogOptions,
             TestContext.Current.CancellationToken
         );
-
-        // Assert
-        result.ShouldBeEmpty();
 
         // Error log file should exist (in real file system for this test)
         string fileContents = await System.IO.File.ReadAllTextAsync(

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
@@ -94,7 +94,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         );
 
         // Assert
-        result.ShouldBe("Good message 1");
+        result.ShouldBeEmpty();
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         );
 
         // Assert
-        result.ShouldBe("Good message 1");
+        result.ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
### Improvements

- Switch from AES CBC to the AES GCM stream cypher
- Max message length increased from 10 MB to 2 GB
- Write directly into the `_underlyingStream`. No more memory pressure for large logs
- Removed the second header marker and body markers (smaller file size)
- Introduced escaping to prevent data with the same binary sequence as the header marker
- Overall performance improvement by roughly 40%

I am not sure whether it is smart to skip renewing the `AesGcm` object during the `Flush` operation. I don’t know when or how Serilog will create a new `EncryptedStream`. If it never does, this could potentially result in significant data loss if a single log message becomes corrupted, because we would never encounter a new header marker. Maybe you can provide more insight on that.