### PR TITLE
Refactor writer and reader to remove escaping

### DIFF
--- a/examples/Example.Benchmarks/Benchmarks.md
+++ b/examples/Example.Benchmarks/Benchmarks.md
@@ -27,6 +27,8 @@ The benchmarks show excellent performance with `buffered: true`, but be aware th
 
 ### Encrypted Stream Benchmarks
 
+#### Original: AES-CBC no Escaping
+
 Run 1:
 
 | Method                     | BufferSize |         Mean |      Error |     StdDev |    Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
@@ -53,7 +55,7 @@ Run 2:
 | PlainMemoryStreamWrite     | 2048       |     62.74 ns |   1.272 ns |   2.358 ns |     1.00 |    0.05 | 0.0408 | 0.0001 |    2048 B |        1.00 |
 | EncryptedMemoryStreamWrite | 2048       | 28,190.59 ns |  99.900 ns |  88.559 ns |   449.90 |   16.43 | 0.2747 |      - |   14120 B |        6.89 |
 
-#### Refactored Encrypted Stream Benchmarks
+#### Refactored: AES-GCM /w Escaping
 
 Run 1:
 
@@ -81,7 +83,37 @@ Run 2:
 | **PlainMemoryStreamWrite** | **2048**   | **57.97 ns** | **0.175 ns** | **0.155 ns** | **1.00** | **0.00** | **0.0408** | **0.0001** | **2048 B** |    **1.00** |
 | EncryptedMemoryStreamWrite | 2048       | 38,903.03 ns |    48.255 ns |    42.776 ns |   671.14 |     1.88 |     0.1221 |          - |     7200 B |        3.52 |
 
+#### Refactored: AES-GCM w/o Escaping
+
+Run 1:
+
+| Method                     | BufferSize |         Mean |        Error |       StdDev |    Ratio |  RatioSD |       Gen0 |       Gen1 |  Allocated | Alloc Ratio |
+|----------------------------|------------|-------------:|-------------:|-------------:|---------:|---------:|-----------:|-----------:|-----------:|------------:|
+| **PlainMemoryStreamWrite** | **512**    | **23.20 ns** | **0.051 ns** | **0.048 ns** | **1.00** | **0.00** | **0.0105** |      **-** |  **528 B** |    **1.00** |
+| EncryptedMemoryStreamWrite | 512        | 13,592.41 ns |    18.290 ns |    17.109 ns |   585.98 |     1.37 |     0.0458 |          - |     3016 B |        5.71 |
+|                            |            |              |              |              |          |          |            |            |            |             |
+| **PlainMemoryStreamWrite** | **1024**   | **32.41 ns** | **0.096 ns** | **0.090 ns** | **1.00** | **0.00** | **0.0191** |      **-** |  **960 B** |    **1.00** |
+| EncryptedMemoryStreamWrite | 1024       | 13,669.05 ns |    29.925 ns |    27.992 ns |   421.76 |     1.41 |     0.0610 |          - |     3568 B |        3.72 |
+|                            |            |              |              |              |          |          |            |            |            |             |
+| **PlainMemoryStreamWrite** | **2048**   | **57.97 ns** | **0.134 ns** | **0.125 ns** | **1.00** | **0.00** | **0.0408** | **0.0001** | **2048 B** |    **1.00** |
+| EncryptedMemoryStreamWrite | 2048       | 13,872.49 ns |    19.956 ns |    16.664 ns |   239.29 |     0.57 |     0.1068 |          - |     5752 B |        2.81 |
+
+Run 2:
+
+| Method                     | BufferSize |         Mean |        Error |       StdDev |    Ratio |  RatioSD |       Gen0 |       Gen1 |  Allocated | Alloc Ratio |
+|----------------------------|------------|-------------:|-------------:|-------------:|---------:|---------:|-----------:|-----------:|-----------:|------------:|
+| **PlainMemoryStreamWrite** | **512**    | **23.31 ns** | **0.054 ns** | **0.051 ns** | **1.00** | **0.00** | **0.0105** |      **-** |  **528 B** |    **1.00** |
+| EncryptedMemoryStreamWrite | 512        | 13,600.19 ns |    42.163 ns |    37.376 ns |   583.49 |     1.98 |     0.0458 |          - |     3016 B |        5.71 |
+|                            |            |              |              |              |          |          |            |            |            |             |
+| **PlainMemoryStreamWrite** | **1024**   | **31.88 ns** | **0.108 ns** | **0.101 ns** | **1.00** | **0.00** | **0.0190** |      **-** |  **952 B** |    **1.00** |
+| EncryptedMemoryStreamWrite | 1024       | 13,706.63 ns |    16.332 ns |    15.277 ns |   429.95 |     1.40 |     0.0610 |          - |     3576 B |        3.76 |
+|                            |            |              |              |              |          |          |            |            |            |             |
+| **PlainMemoryStreamWrite** | **2048**   | **58.22 ns** | **0.211 ns** | **0.197 ns** | **1.00** | **0.00** | **0.0408** | **0.0001** | **2048 B** |    **1.00** |
+| EncryptedMemoryStreamWrite | 2048       | 13,946.36 ns |    20.492 ns |    19.168 ns |   239.56 |     0.85 |     0.1068 |          - |     5752 B |        2.81 |
+
 ### Serilog File Sink Benchmarks
+
+#### Original: AES-CBC no Escaping
 
 Run 1:
 
@@ -163,7 +195,7 @@ Run 2:
 | LogWithEncryption         | 10000         | Small       | 30,260.0 us | 206.22 us | 172.20 us | 30,234.8 us |  1.14 |    0.03 |                    - |                - |  156.2500 |         - |         - |  8151.39 KB |        5.18 |
 | LogWithEncryptionBuffered | 10000         | Small       |  4,415.2 us |  66.52 us |  51.93 us |  4,407.0 us |  0.17 |    0.00 |                    - |                - |  742.1875 |  742.1875 |  742.1875 |   4227.5 KB |        2.68 |
 
-#### Refactored Serilog File Sink Benchmarks
+#### Refactored: AES-GCM /w Escaping
 
 Run 1:
 
@@ -245,9 +277,93 @@ Run 2:
 | LogWithEncryption         | 10000         | Small       |     25,682.4 μs |     157.40 μs |     147.23 μs |     25,646.9 μs |     1.14 |     0.01 |      31.2500 |                    - |                - |       1901.1 KB |        1.21 |
 | LogWithEncryptionBuffered | 10000         | Small       |      4,146.8 μs |      79.17 μs |      88.00 μs |      4,102.4 μs |     0.18 |     0.00 |      31.2500 |                    - |                - |      1609.94 KB |        1.02 |
 
+#### Refactored: AES-GCM w/o Escaping
+
+Run 1:
+
+| Method                    | LogEntryCount | MessageSize |            Mean |         Error |        StdDev |          Median |    Ratio |  RatioSD |         Gen0 | Completed Work Items | Lock Contentions |       Allocated | Alloc Ratio |
+|---------------------------|---------------|-------------|----------------:|--------------:|--------------:|----------------:|---------:|---------:|-------------:|---------------------:|-----------------:|----------------:|------------:|
+| **LogWithoutEncryption**  | **100**       | **Large**   |    **787.7 μs** |   **9.83 μs** |   **8.21 μs** |    **788.0 μs** | **1.00** | **0.01** |   **3.9063** |                **-** |            **-** |   **235.19 KB** |    **1.00** |
+| LogWithEncryption         | 100           | Large       |        746.3 μs |      14.28 μs |      17.00 μs |        737.8 μs |     0.95 |     0.02 |       3.9063 |                    - |                - |       251.23 KB |        1.07 |
+| LogWithEncryptionBuffered | 100           | Large       |        587.1 μs |      11.45 μs |      28.51 μs |        586.0 μs |     0.75 |     0.04 |       3.9063 |                    - |                - |       249.47 KB |        1.06 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **100**       | **Medium**  |    **660.8 μs** |  **18.25 μs** |  **52.37 μs** |    **649.3 μs** | **1.01** | **0.11** |   **0.9766** |                **-** |            **-** |    **75.13 KB** |    **1.00** |
+| LogWithEncryption         | 100           | Medium      |        674.1 μs |       9.24 μs |       8.19 μs |        676.1 μs |     1.03 |     0.08 |            - |                    - |                - |        91.15 KB |        1.21 |
+| LogWithEncryptionBuffered | 100           | Medium      |        360.7 μs |       3.65 μs |       3.05 μs |        361.2 μs |     0.55 |     0.04 |       0.9766 |                    - |                - |        91.53 KB |        1.22 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **100**       | **Small**   |    **561.6 μs** |   **6.58 μs** |   **6.15 μs** |    **561.9 μs** | **1.00** | **0.01** |        **-** |                **-** |            **-** |    **28.11 KB** |    **1.00** |
+| LogWithEncryption         | 100           | Small       |        651.1 μs |       4.18 μs |       3.49 μs |        651.1 μs |     1.16 |     0.01 |            - |                    - |                - |        44.15 KB |        1.57 |
+| LogWithEncryptionBuffered | 100           | Small       |        400.7 μs |      31.54 μs |      87.39 μs |        367.0 μs |     0.71 |     0.16 |       0.4883 |                    - |                - |         44.2 KB |        1.57 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **1000**      | **Large**   |  **4,194.9 μs** |  **80.96 μs** |  **93.24 μs** |  **4,157.7 μs** | **1.00** | **0.03** |  **31.2500** |                **-** |            **-** |  **2225.83 KB** |    **1.00** |
+| LogWithEncryption         | 1000          | Large       |      4,500.0 μs |      88.87 μs |      95.09 μs |      4,463.3 μs |     1.07 |     0.03 |      31.2500 |                    - |                - |      2270.04 KB |        1.02 |
+| LogWithEncryptionBuffered | 1000          | Large       |      2,625.1 μs |      50.95 μs |      47.66 μs |      2,604.8 μs |     0.63 |     0.02 |      39.0625 |                    - |                - |      2252.68 KB |        1.01 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **1000**      | **Medium**  |  **3,547.6 μs** | **197.25 μs** | **543.29 μs** |  **3,244.5 μs** | **1.02** | **0.21** |   **7.8125** |                **-** |            **-** |   **652.49 KB** |    **1.00** |
+| LogWithEncryption         | 1000          | Medium      |      3,494.2 μs |      45.59 μs |      38.07 μs |      3,489.0 μs |     1.01 |     0.13 |            - |                    - |                - |       696.62 KB |        1.07 |
+| LogWithEncryptionBuffered | 1000          | Medium      |      1,189.7 μs |      23.06 μs |      41.59 μs |      1,173.7 μs |     0.34 |     0.05 |      11.7188 |                    - |                - |       672.77 KB |        1.03 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **1000**      | **Small**   |  **2,592.6 μs** |  **27.09 μs** |  **30.11 μs** |  **2,606.2 μs** | **1.00** | **0.02** |        **-** |                **-** |            **-** |   **168.74 KB** |    **1.00** |
+| LogWithEncryption         | 1000          | Small       |      2,981.4 μs |      58.32 μs |      51.70 μs |      2,955.7 μs |     1.15 |     0.02 |            - |                    - |                - |       212.91 KB |        1.26 |
+| LogWithEncryptionBuffered | 1000          | Small       |        673.2 μs |      12.35 μs |      13.72 μs |        673.6 μs |     0.26 |     0.01 |       1.9531 |                    - |                - |       186.48 KB |        1.11 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **10000**     | **Large**   | **39,276.2 μs** | **543.44 μs** | **508.34 μs** | **39,220.2 μs** | **1.00** | **0.02** | **363.6364** |                **-** |            **-** | **22265.03 KB** |    **1.00** |
+| LogWithEncryption         | 10000         | Large       |     42,032.1 μs |     593.86 μs |     495.90 μs |     42,202.6 μs |     1.07 |     0.02 |     416.6667 |                    - |                - |     22590.82 KB |        1.01 |
+| LogWithEncryptionBuffered | 10000         | Large       |     23,108.1 μs |     375.07 μs |     350.84 μs |     23,137.5 μs |     0.59 |     0.01 |     437.5000 |                    - |                - |     22417.65 KB |        1.01 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **10000**     | **Medium**  | **26,465.1 μs** | **186.26 μs** | **145.42 μs** | **26,467.0 μs** | **1.00** | **0.01** | **125.0000** |                **-** |            **-** |  **6558.78 KB** |    **1.00** |
+| LogWithEncryption         | 10000         | Medium      |     30,480.6 μs |     596.65 μs |     775.81 μs |     30,422.8 μs |     1.15 |     0.03 |     100.0000 |                    - |                - |      6884.36 KB |        1.05 |
+| LogWithEncryptionBuffered | 10000         | Medium      |      8,705.1 μs |     139.00 μs |     130.02 μs |      8,756.4 μs |     0.33 |     0.01 |     125.0000 |                    - |                - |      6618.98 KB |        1.01 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **10000**     | **Small**   | **22,581.4 μs** | **253.90 μs** | **212.02 μs** | **22,617.8 μs** | **1.00** | **0.01** |  **31.2500** |                **-** |            **-** |  **1575.01 KB** |    **1.00** |
+| LogWithEncryption         | 10000         | Small       |     26,095.6 μs |     228.35 μs |     190.68 μs |     26,166.2 μs |     1.16 |     0.01 |      31.2500 |                    - |                - |      1900.47 KB |        1.21 |
+| LogWithEncryptionBuffered | 10000         | Small       |      4,286.8 μs |      84.21 μs |     120.77 μs |      4,258.6 μs |     0.19 |     0.01 |      31.2500 |                    - |                - |      1609.31 KB |        1.02 |
+
+Run 2:
+
+| Method                    | LogEntryCount | MessageSize |            Mean |         Error |        StdDev |          Median |    Ratio |  RatioSD |         Gen0 | Completed Work Items | Lock Contentions |       Allocated | Alloc Ratio |
+|---------------------------|---------------|-------------|----------------:|--------------:|--------------:|----------------:|---------:|---------:|-------------:|---------------------:|-----------------:|----------------:|------------:|
+| **LogWithoutEncryption**  | **100**       | **Large**   |    **737.1 μs** |   **6.13 μs** |   **4.79 μs** |    **738.0 μs** | **1.00** | **0.01** |   **3.9063** |                **-** |            **-** |   **235.19 KB** |    **1.00** |
+| LogWithEncryption         | 100           | Large       |        742.8 μs |      14.70 μs |      24.56 μs |        736.7 μs |     1.01 |     0.03 |       3.9063 |                    - |                - |       251.21 KB |        1.07 |
+| LogWithEncryptionBuffered | 100           | Large       |        565.0 μs |      10.80 μs |      25.87 μs |        554.4 μs |     0.77 |     0.04 |       3.9063 |                    - |                - |       249.47 KB |        1.06 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **100**       | **Medium**  |    **600.1 μs** |   **9.40 μs** |   **7.85 μs** |    **598.1 μs** | **1.00** | **0.02** |   **0.9766** |                **-** |            **-** |    **75.13 KB** |    **1.00** |
+| LogWithEncryption         | 100           | Medium      |        683.0 μs |      10.92 μs |       9.68 μs |        681.1 μs |     1.14 |     0.02 |       0.9766 |                    - |                - |        91.16 KB |        1.21 |
+| LogWithEncryptionBuffered | 100           | Medium      |        360.8 μs |       4.26 μs |       3.33 μs |        360.6 μs |     0.60 |     0.01 |       0.9766 |                    - |                - |        91.47 KB |        1.22 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **100**       | **Small**   |    **572.4 μs** |   **8.76 μs** |   **7.31 μs** |    **571.1 μs** | **1.00** | **0.02** |        **-** |                **-** |            **-** |    **28.11 KB** |    **1.00** |
+| LogWithEncryption         | 100           | Small       |        652.6 μs |       3.96 μs |       3.31 μs |        652.2 μs |     1.14 |     0.01 |            - |                    - |                - |        44.07 KB |        1.57 |
+| LogWithEncryptionBuffered | 100           | Small       |        321.1 μs |       3.67 μs |       3.06 μs |        319.7 μs |     0.56 |     0.01 |            - |                    - |                - |        44.26 KB |        1.57 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **1000**      | **Large**   |  **4,139.5 μs** |  **43.76 μs** |  **36.54 μs** |  **4,141.4 μs** | **1.00** | **0.01** |  **31.2500** |                **-** |            **-** |  **2225.83 KB** |    **1.00** |
+| LogWithEncryption         | 1000          | Large       |      4,467.1 μs |      38.70 μs |      32.32 μs |      4,462.9 μs |     1.08 |     0.01 |      31.2500 |                    - |                - |      2269.96 KB |        1.02 |
+| LogWithEncryptionBuffered | 1000          | Large       |      2,609.9 μs |      17.43 μs |      14.56 μs |      2,615.3 μs |     0.63 |     0.01 |      39.0625 |                    - |                - |      2252.63 KB |        1.01 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **1000**      | **Medium**  |  **2,999.0 μs** |  **26.30 μs** |  **21.96 μs** |  **2,991.6 μs** | **1.00** | **0.01** |   **7.8125** |                **-** |            **-** |   **652.49 KB** |    **1.00** |
+| LogWithEncryption         | 1000          | Medium      |      3,345.0 μs |      10.81 μs |       9.03 μs |      3,343.5 μs |     1.12 |     0.01 |       7.8125 |                    - |                - |       696.66 KB |        1.07 |
+| LogWithEncryptionBuffered | 1000          | Medium      |      1,122.8 μs |       8.24 μs |       7.30 μs |      1,125.2 μs |     0.37 |     0.00 |      11.7188 |                    - |                - |       672.77 KB |        1.03 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **1000**      | **Small**   |  **2,603.5 μs** |  **17.11 μs** |  **13.36 μs** |  **2,601.7 μs** | **1.00** | **0.01** |        **-** |                **-** |            **-** |   **168.74 KB** |    **1.00** |
+| LogWithEncryption         | 1000          | Small       |      2,892.5 μs |      14.73 μs |      12.30 μs |      2,888.6 μs |     1.11 |     0.01 |            - |                    - |                - |       212.83 KB |        1.26 |
+| LogWithEncryptionBuffered | 1000          | Small       |        674.8 μs |      11.38 μs |       9.50 μs |        674.5 μs |     0.26 |     0.00 |       1.9531 |                    - |                - |       186.48 KB |        1.11 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **10000**     | **Large**   | **37,867.3 μs** | **178.52 μs** | **158.26 μs** | **37,859.9 μs** | **1.00** | **0.01** | **384.6154** |                **-** |            **-** | **22265.02 KB** |    **1.00** |
+| LogWithEncryption         | 10000         | Large       |     41,857.4 μs |     258.13 μs |     241.46 μs |     41,820.1 μs |     1.11 |     0.01 |     416.6667 |                    - |                - |     22590.87 KB |        1.01 |
+| LogWithEncryptionBuffered | 10000         | Large       |     22,820.3 μs |     132.80 μs |     117.73 μs |     22,846.4 μs |     0.60 |     0.00 |     437.5000 |                    - |                - |     22417.71 KB |        1.01 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **10000**     | **Medium**  | **26,168.1 μs** | **122.60 μs** |  **95.72 μs** | **26,161.9 μs** | **1.00** | **0.00** | **125.0000** |                **-** |            **-** |  **6558.78 KB** |    **1.00** |
+| LogWithEncryption         | 10000         | Medium      |     29,712.0 μs |     133.03 μs |     117.93 μs |     29,688.5 μs |     1.14 |     0.01 |      76.9231 |                    - |                - |       6884.3 KB |        1.05 |
+| LogWithEncryptionBuffered | 10000         | Medium      |      8,388.3 μs |      42.99 μs |      35.90 μs |      8,393.2 μs |     0.32 |     0.00 |     125.0000 |                    - |                - |      6618.98 KB |        1.01 |
+|                           |               |             |                 |               |               |                 |          |          |              |                      |                  |                 |             |
+| **LogWithoutEncryption**  | **10000**     | **Small**   | **22,344.8 μs** | **107.57 μs** |  **95.35 μs** | **22,326.0 μs** | **1.00** | **0.01** |        **-** |                **-** |            **-** |  **1575.05 KB** |    **1.00** |
+| LogWithEncryption         | 10000         | Small       |     25,526.2 μs |      81.35 μs |      67.93 μs |     25,515.2 μs |     1.14 |     0.01 |      31.2500 |                    - |                - |      1900.41 KB |        1.21 |
+| LogWithEncryptionBuffered | 10000         | Small       |      4,275.5 μs |      30.97 μs |      27.46 μs |      4,271.7 μs |     0.19 |     0.00 |      31.2500 |                    - |                - |      1609.29 KB |        1.02 |
+
 ### Simulated Scenario Benchmarks
 
 #### Web API Request Simulation
+
+##### Original: AES-CBC
 
 Run 1:
 
@@ -269,7 +385,7 @@ Run 2:
 | SimulateApiRequestsWithoutEncryption | 1000         | 4,460.7 us |  88.87 us | 185.51 us |  1.00 |    0.06 |                    - |                - | 15.6250 |   999.1 KB |        1.00 |
 | SimulateApiRequestsWithEncryption    | 1000         | 5,117.5 us | 101.66 us | 253.17 us |  1.15 |    0.07 |                    - |                - | 31.2500 | 1889.29 KB |        1.89 |
 
-##### Refactored Web API Request Simulation
+##### Refactored: AES-GCM /w Escaping
 
 Run 1:
 
@@ -291,7 +407,31 @@ Run 2:
 | **SimulateApiRequestsWithoutEncryption** | **1000**     | **3,556.7 μs** | **27.30 μs** | **26.82 μs** | **1.00** | **0.01** |      **-** |                **-** |            **-** | **999.11 KB** |    **1.00** |
 | SimulateApiRequestsWithEncryption        | 1000         |     4,017.7 μs |     26.66 μs |     23.64 μs |     1.13 |     0.01 |    15.6250 |                    - |                - |    1049.45 KB |        1.05 |
 
+##### Refactored: AES-GCM w/o Escaping
+
+Run 1:
+
+| Method                                   | RequestCount |           Mean |        Error |       StdDev |         Median |    Ratio |  RatioSD |        Gen0 | Completed Work Items | Lock Contentions |      Allocated | Alloc Ratio |
+|------------------------------------------|--------------|---------------:|-------------:|-------------:|---------------:|---------:|---------:|------------:|---------------------:|-----------------:|---------------:|------------:|
+| **SimulateApiRequestsWithoutEncryption** | **100**      |   **400.9 μs** | **15.34 μs** | **43.26 μs** |   **381.9 μs** | **1.01** | **0.14** |  **1.9531** |                **-** |            **-** |   **117.6 KB** |    **1.00** |
+| SimulateApiRequestsWithEncryption        | 100          |       441.1 μs |     15.37 μs |     42.58 μs |       424.8 μs |     1.11 |     0.15 |      1.9531 |                    - |                - |      131.08 KB |        1.11 |
+|                                          |              |                |              |              |                |          |          |             |                      |                  |                |             |
+| **SimulateApiRequestsWithoutEncryption** | **1000**     | **1,326.5 μs** | **22.42 μs** | **33.56 μs** | **1,320.8 μs** | **1.00** | **0.03** | **19.5313** |                **-** |            **-** | **1002.41 KB** |    **1.00** |
+| SimulateApiRequestsWithEncryption        | 1000         |     1,519.0 μs |     30.10 μs |     69.76 μs |     1,488.7 μs |     1.15 |     0.06 |     15.6250 |                    - |                - |     1020.69 KB |        1.02 |
+
+Run 2:
+
+| Method                                   | RequestCount |           Mean |        Error |       StdDev |         Median |    Ratio |  RatioSD |        Gen0 | Completed Work Items | Lock Contentions |      Allocated | Alloc Ratio |
+|------------------------------------------|--------------|---------------:|-------------:|-------------:|---------------:|---------:|---------:|------------:|---------------------:|-----------------:|---------------:|------------:|
+| **SimulateApiRequestsWithoutEncryption** | **100**      |   **374.4 μs** |  **8.68 μs** | **23.18 μs** |   **366.2 μs** | **1.00** | **0.08** |  **1.9531** |           **0.0010** |            **-** |   **117.6 KB** |    **1.00** |
+| SimulateApiRequestsWithEncryption        | 100          |       435.2 μs |     10.26 μs |     29.09 μs |       422.8 μs |     1.17 |     0.10 |      1.9531 |               0.0010 |                - |         131 KB |        1.11 |
+|                                          |              |                |              |              |                |          |          |             |                      |                  |                |             |
+| **SimulateApiRequestsWithoutEncryption** | **1000**     | **1,312.0 μs** | **25.71 μs** | **42.24 μs** | **1,291.5 μs** | **1.00** | **0.04** | **19.5313** |           **0.0039** |            **-** | **1002.41 KB** |    **1.00** |
+| SimulateApiRequestsWithEncryption        | 1000         |     1,481.6 μs |     26.31 μs |     67.92 μs |     1,457.5 μs |     1.13 |     0.06 |     15.6250 |                    - |                - |     1020.69 KB |        1.02 |
+
 #### Background Worker Simulation
+
+##### Original: AES-CBC
 
 Run 1:
 
@@ -313,7 +453,7 @@ Run 2:
 | SimulateBackgroundWorkerWithoutEncryption | 10000        | 6.025 ms | 0.1066 ms | 0.0890 ms |  1.00 |    0.02 |                    - |                - |  85.9375 |        - |        - |   4.34 MB |        1.00 |
 | SimulateBackgroundWorkerWithEncryption    | 10000        | 6.480 ms | 0.0676 ms | 0.0599 ms |  1.08 |    0.02 |                    - |                - | 757.8125 | 671.8750 | 671.8750 |   7.13 MB |        1.64 |
 
-##### Refactored Background Worker Simulation
+##### Refactored: AES-GCM /w Escaping Background Worker Simulation
 
 Run 1:
 
@@ -334,3 +474,25 @@ Run 2:
 |                                               |              |              |               |               |          |             |                      |                  |             |             |
 | **SimulateBackgroundWorkerWithoutEncryption** | **10000**    | **5.680 ms** | **0.0350 ms** | **0.0292 ms** | **1.00** | **85.9375** |                **-** |            **-** | **4.34 MB** |    **1.00** |
 | SimulateBackgroundWorkerWithEncryption        | 10000        |     6.128 ms |     0.0343 ms |     0.0304 ms |     1.08 |     85.9375 |                    - |                - |     4.38 MB |        1.01 |
+
+##### Refactored: AES-GCM w/o Escaping Background Worker Simulation
+
+Run 1:
+
+| Method                                        | MessageCount |         Mean |         Error |        StdDev |    Ratio |  RatioSD |        Gen0 | Completed Work Items | Lock Contentions |   Allocated | Alloc Ratio |
+|-----------------------------------------------|--------------|-------------:|--------------:|--------------:|---------:|---------:|------------:|---------------------:|-----------------:|------------:|------------:|
+| **SimulateBackgroundWorkerWithoutEncryption** | **5000**     | **3.032 ms** | **0.0574 ms** | **0.0805 ms** | **1.00** | **0.04** | **31.2500** |                **-** |            **-** | **2.18 MB** |    **1.00** |
+| SimulateBackgroundWorkerWithEncryption        | 5000         |     3.160 ms |     0.0307 ms |     0.0240 ms |     1.04 |     0.03 |     31.2500 |                    - |                - |      2.2 MB |        1.01 |
+|                                               |              |              |               |               |          |          |             |                      |                  |             |             |
+| **SimulateBackgroundWorkerWithoutEncryption** | **10000**    | **5.909 ms** | **0.0820 ms** | **0.0685 ms** | **1.00** | **0.02** | **85.9375** |                **-** |            **-** | **4.34 MB** |    **1.00** |
+| SimulateBackgroundWorkerWithEncryption        | 10000        |     6.337 ms |     0.0890 ms |     0.0743 ms |     1.07 |     0.02 |     85.9375 |                    - |                - |     4.38 MB |        1.01 |
+
+Run 2:
+
+| Method                                        | MessageCount |         Mean |         Error |        StdDev |    Ratio |        Gen0 | Completed Work Items | Lock Contentions |   Allocated | Alloc Ratio |
+|-----------------------------------------------|--------------|-------------:|--------------:|--------------:|---------:|------------:|---------------------:|-----------------:|------------:|------------:|
+| **SimulateBackgroundWorkerWithoutEncryption** | **5000**     | **3.015 ms** | **0.0270 ms** | **0.0240 ms** | **1.00** | **31.2500** |                **-** |            **-** | **2.18 MB** |    **1.00** |
+| SimulateBackgroundWorkerWithEncryption        | 5000         |     3.285 ms |     0.0170 ms |     0.0151 ms |     1.09 |     31.2500 |                    - |                - |      2.2 MB |        1.01 |
+|                                               |              |              |               |               |          |             |                      |                  |             |             |
+| **SimulateBackgroundWorkerWithoutEncryption** | **10000**    | **5.675 ms** | **0.0281 ms** | **0.0219 ms** | **1.00** | **85.9375** |                **-** |            **-** | **4.34 MB** |    **1.00** |
+| SimulateBackgroundWorkerWithEncryption        | 10000        |     6.256 ms |     0.0376 ms |     0.0333 ms |     1.10 |     85.9375 |                    - |                - |     4.38 MB |        1.01 |

--- a/examples/Example.Benchmarks/README.md
+++ b/examples/Example.Benchmarks/README.md
@@ -25,77 +25,96 @@ Results are saved to `BenchmarkDotNet.Artifacts/results/` with HTML, CSV, and Ma
 
 ### At a Glance
 
+#### Time Overhead Benchmark Summary
+The fuller the bar the more time overhead compared to baseline.
+(lower is better)
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ GOAL: Time Overhead < 50%  (Serilog File Sink, 100 entries)     │
+| Baseline (no encryption): ~680 μs for 100 entries               │
 │ AES:                                                            │
-│ ██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  1-8% (unbuffered)     │
+│ █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  1-8% (unbuffered)     │
 │ FASTER ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  -23 to -35% (buff.)   │
 │ AES-GCM:                                                        │
-│ █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  3-5% (unbuffered)     │
-│ FASTER ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  -18 to -20% (buff.)   │
-│ At 10K entries: AES → ~18%, AES-GCM → ~9%                      │
+│ █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  0-8% (unbuffered)     │
+│ FASTER ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  -25 to -45% (buff.)   │
+│ At 10K entries: AES → ~18%, AES-GCM → ~7-16%                    │
 │ STATUS PASS - Well within target                                │
 └─────────────────────────────────────────────────────────────────┘
+```
 
+#### Memory Overhead Benchmark Summary
+
+The fuller the bar the more memory used compared to baseline.
+(lower is better)
+```
 ┌─────────────────────────────────────────────────────────────────┐
-│ GOAL: Memory Overhead < 2x  (Serilog File Sink, Medium msgs)    │
+│ GOAL: Memory Overhead < 2x (Serilog File Sink, Medium msgs)     │
+│ Baseline (no encryption): ~652.49 KB for 1000 entries           │
 │ AES:                                                            │
-│ ███████████████████████████░░░░░░░░░░░░░  1.90x (unbuffered)    │
-│ ████████████████████████████████████░░░░  2.15x (buffered)      │
+│ ████████████████████████░░░░░░░░░░░░░░░░  2.15x (unbuffered)    │ 
+│ ███████████████████████░░░░░░░░░░░░░░░░░░  2.02x (buffered)     │
 │ AES-GCM:                                                        │
 │ ██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  1.06x (unbuffered)    │
 │ █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  1.02x (buffered)      │
 │ STATUS: AES can exceed 2x on smaller msgs                       │
 │         AES-GCM PASS ~5% more memory well under 2x              │
 └─────────────────────────────────────────────────────────────────┘
+```
+#### Throughput Benchmark Summary
 
+The fuller the bar the closer to matching baseline.
+(higher is better)
+```
 ┌─────────────────────────────────────────────────────────────────┐
 │ GOAL: Throughput > 1,500 logs/sec  (Serilog Sink, Small, 100)   │
 │ Full logging pipeline: Serilog formatting + file I/O + encrypt  │
+| Baseline (no encryption): ~1,760 logs/sec                       |
 │ AES:                                                            │
-│ ██████████████████████░░░░░░░░░░░░░░░░░░░  1,696 (unbuffered)   │
-│ ████████████████████████████████░░░░░░░░░  2,733 (buffered)     │
+│ ███████████████████████████████████████░  1,696 (unbuffered)    │
+│ FASTER ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  2,733 (buffered)      │
 │ AES-GCM:                                                        │
-│ ███████████████████████░░░░░░░░░░░░░░░░░░  1,786 (unbuffered)   │
-│ █████████████████████████████████░░░░░░░░  2,859 (buffered)     │
-│ STATUS: PASS - Exceeds target by 1.1-1.9x                       │
-│ (Raw EncryptedStream: ~25K writes/sec - see stream bench)       │
+│ ████████████████████████████████████░░░░  1,534 (unbuffered)    │
+│ FASTER ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  2,700 (buffered)      │
+│ STATUS: PASS - Exceeds 1,500/sec target by 1.1-1.9x             │
+│ (Raw EncryptedStream: ~70K writes/sec - see stream bench)       │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
 ### Real-World Scenarios
 
-**Serilog File Sink - Medium Messages (100 entries)**
+**Serilog File Sink - Medium Messages (1000 entries)**
 ```
                                               AES-GCM
-                   Baseline       Unnbuffered        Buffered
-No Encryption:     593 μs         636 μs  (+8%)      386 μs (-34%) 
-Memory:            75 KB          91 KB   (+22%)     92 KB (+22%)
-Throughput:        1,700/sec      1,573/sec (-7.47%) 2,588/sec (+52%)
+                   Baseline       Unbuffered        Buffered
+No Encryption:     3,000 μs       3,345 μs (+12%)   1,122 μs (-63%)
+Memory:            652 KB         696 KB   (+7%)    672 KB (+3%)
+Throughput:        1,760/sec      1,534/sec (-13%)  2,700/sec (+53%)
 Verdict:           ✅ Unbuffered is default safe choice
+Summary:           AES-GCM: +12% time overhead, +7% more memory, -13% throughput (unbuffered)
+                   Buffered mode: 63% faster, 3% more memory, 53% higher throughput
 ```
 
 **Background Worker (10,000 messages)**
 ```
 buffered: true
                         Baseline        AES-GCM
-Time:                   5.70 ms         6.12 ms  (+7.9%)
-Memory:                 4.34 MB         4.38 MB  (+1.0%)
-Throughput:             ~1,740/sec      ~1,632/sec (-7.25%)
+Time:                   5.70 ms         6.30 ms  (+10%)
+Memory:                 4.34 MB         4.38 MB  (+1%)
+Throughput:             ?/sec           ?/sec (-9.5%)
 Verdict:                ✅ Fine for batch processing and logging to file
-                        AES-GCM: ~half the time overhead, 27% less memory ↗️
+    AES-GCM: ~10% time overhead, < 1% more memory, ~10% less throughput
 ```
 
 **Web API Logging To File.Sink (1,000 requests)**
 ```
 buffered: true
                         Baseline       AES-GCM
-Time:                   1.4 ms         3.91 ms  (+10%)
-Memory:                 999 KB         1,049 KB (+05%)
-Throughput:             ~714 r/s       ~640 r/s (-10%)    
+Time:                   1.32 ms        1.50 ms  (+13%)
+Memory:                 1002 KB        1,020 KB (+2%)
+Throughput:             758 r/s        667 r/s (-12%)    
 Verdict:                ❌️ Writing to a file is not recommended in a Web API
-                        AES-GCM: +10% time overhead, +05% memory️
+    AES-GCM: +14% time overhead, +2% more memory, ~12% less throughput️
 ```
 
 ### Key Findings

--- a/src/Serilog.Sinks.File.Encrypt/EncryptedStream.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptedStream.cs
@@ -39,38 +39,8 @@ namespace Serilog.Sinks.File.Encrypt;
 /// </example>
 public class EncryptedStream : Stream
 {
-    // csharpier-ignore-start
-    private static readonly byte[] _marker = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01];
-    private const byte EscapeMarker = 0x00;
-    // csharpier-ignore-end
-
-    /// <summary>
-    /// length of the nonce in bytes (counter for the stream cipher)
-    /// </summary>
-    private const int NonceLength = 12;
-
-    /// <summary>
-    /// length of the AES session key in bytes
-    /// </summary>
-    private const int SessionKeyLength = 32; // 256 bit
-
-    /// <summary>
-    /// tag (hmac) to confirm data integrity
-    /// </summary>
-    private const int TagLength = 16; // 128 bit
-
-    /// <summary>
-    /// Length prefix size in bytes for each encrypted block (4 bytes for int32)
-    /// </summary>
-    private const int LengthPrefixSize = sizeof(int);
-
-    /// <summary>
-    /// Minimum RSA key size in bits required to securely encrypt the AES session key and nonce.
-    /// </summary>
-    private const int MinRsaKeySize = 2048;
-
     private readonly Stream _underlyingStream;
-    private readonly RSA _rsaPublicKey;
+    private readonly RSA _publicKey;
 
     private AesGcm? _aes;
     private bool _isDisposed;
@@ -80,193 +50,114 @@ public class EncryptedStream : Stream
     /// Creates a new instance of <see cref="EncryptedStream"/> that encrypts data written to the underlying stream.
     /// </summary>
     /// <param name="underlyingStream">The stream to write encrypted data to. Must be writable.</param>
-    /// <param name="rsaPublicKey">The RSA public key used to encrypt the AES-GCM session.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="underlyingStream"/> or <paramref name="rsaPublicKey"/> is null.</exception>
+    /// <param name="publicKey">The RSA public key used to encrypt the AES-GCM session.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="underlyingStream"/> or <paramref name="publicKey"/> is null.</exception>
     /// <exception cref="CryptographicException">Thrown when RSA key operations fail.</exception>
-    public EncryptedStream(Stream underlyingStream, RSA rsaPublicKey)
+    public EncryptedStream(Stream underlyingStream, RSA publicKey)
     {
         ArgumentNullException.ThrowIfNull(underlyingStream);
-        ArgumentNullException.ThrowIfNull(rsaPublicKey);
-        ArgumentOutOfRangeException.ThrowIfLessThan(rsaPublicKey.KeySize, MinRsaKeySize);
+        ArgumentNullException.ThrowIfNull(publicKey);
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            publicKey.KeySize,
+            EncryptionConstants.MinRsaKeySize
+        );
 
         _underlyingStream = underlyingStream;
-        _rsaPublicKey = rsaPublicKey;
+        _publicKey = publicKey;
     }
 
     private void StartNewEncryptionChunk()
     {
-        byte[] sessionKey = ArrayPool<byte>.Shared.Rent(SessionKeyLength);
+        byte[] header = ArrayPool<byte>.Shared.Rent(EncryptionConstants.HeaderUnencryptedSize);
         try
         {
-            _nonce = new byte[NonceLength];
+            _nonce = new byte[EncryptionConstants.NonceLength];
 
-            RandomNumberGenerator.Fill(sessionKey.AsSpan(0, SessionKeyLength));
+            RandomNumberGenerator.Fill(
+                header.AsSpan(
+                    EncryptionConstants.HeaderSessionKeyOffset,
+                    EncryptionConstants.SessionKeyLength
+                )
+            );
             RandomNumberGenerator.Fill(_nonce);
 
-            _aes = new AesGcm(sessionKey.AsSpan(0, SessionKeyLength), TagLength);
-
-            byte[] encryptedTagSize = _rsaPublicKey.Encrypt(
-                BitConverter.GetBytes(TagLength),
-                RSAEncryptionPadding.OaepSHA256
-            );
-            byte[] encryptedNonce = _rsaPublicKey.Encrypt(_nonce, RSAEncryptionPadding.OaepSHA256);
-            byte[] encryptedSessionKey = _rsaPublicKey.Encrypt(
-                sessionKey.AsSpan(0, SessionKeyLength).ToArray(),
-                RSAEncryptionPadding.OaepSHA256
+            _aes = new AesGcm(
+                header.AsSpan(
+                    EncryptionConstants.HeaderSessionKeyOffset,
+                    EncryptionConstants.SessionKeyLength
+                ),
+                EncryptionConstants.TagLength
             );
 
-            byte[] encryptedTagSizeLength = BitConverter.GetBytes(encryptedTagSize.Length);
-            byte[] encryptedNonceLength = BitConverter.GetBytes(encryptedNonce.Length);
-            byte[] encryptedSessionKeyLength = BitConverter.GetBytes(encryptedSessionKey.Length);
+            BitConverter.GetBytes(EncryptionConstants.TagLength).CopyTo(header, 0);
+            _nonce.CopyTo(header, EncryptionConstants.HeaderNonceOffset);
 
-            // Combine all header data and check for markers once
-            int headerUnescapedLength =
-                encryptedTagSize.Length + encryptedNonce.Length + encryptedSessionKey.Length;
-            int maxHeaderSize =
-                headerUnescapedLength + (headerUnescapedLength / _marker.Length) + 1;
-            byte[] finalHeaderBuffer = ArrayPool<byte>.Shared.Rent(maxHeaderSize);
+            byte[] encryptedRsaHeader = _publicKey.Encrypt(
+                header.AsSpan(0, EncryptionConstants.HeaderUnencryptedSize).ToArray(),
+                RSAEncryptionPadding.OaepSHA256
+            );
 
-            try
-            {
-                int unescapedPos = 0;
-                encryptedTagSize.CopyTo(finalHeaderBuffer.AsSpan(unescapedPos));
-                unescapedPos += encryptedTagSize.Length;
-                encryptedNonce.CopyTo(finalHeaderBuffer.AsSpan(unescapedPos));
-                unescapedPos += encryptedNonce.Length;
-                encryptedSessionKey.CopyTo(finalHeaderBuffer.AsSpan(unescapedPos));
-
-                // Fast path: check if escaping is needed
-                Span<byte> unescapedHeader = finalHeaderBuffer.AsSpan(0, headerUnescapedLength);
-                int markerPos = unescapedHeader.IndexOf(_marker);
-
-                int finalHeaderLength =
-                    (markerPos == -1)
-                        ? headerUnescapedLength
-                        : EscapeMarkersInHeader(unescapedHeader, finalHeaderBuffer);
-
-                _underlyingStream.Write(_marker);
-                _underlyingStream.Write(encryptedTagSizeLength);
-                _underlyingStream.Write(encryptedNonceLength);
-                _underlyingStream.Write(encryptedSessionKeyLength);
-                _underlyingStream.Write(finalHeaderBuffer.AsSpan(0, finalHeaderLength));
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(finalHeaderBuffer);
-            }
+            _underlyingStream.Write(EncryptionConstants.Marker);
+            _underlyingStream.Write(EncryptionConstants.Version);
+            _underlyingStream.Write(encryptedRsaHeader);
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(sessionKey.AsSpan(0, SessionKeyLength));
-            ArrayPool<byte>.Shared.Return(sessionKey);
+            CryptographicOperations.ZeroMemory(
+                header.AsSpan(0, EncryptionConstants.HeaderUnencryptedSize)
+            );
+            ArrayPool<byte>.Shared.Return(header);
         }
     }
 
     private async Task StartNewEncryptionChunkAsync(CancellationToken cancellationToken = default)
     {
-        byte[] sessionKey = ArrayPool<byte>.Shared.Rent(SessionKeyLength);
+        byte[] header = ArrayPool<byte>.Shared.Rent(EncryptionConstants.HeaderUnencryptedSize);
         try
         {
-            _nonce = new byte[NonceLength];
+            _nonce = new byte[EncryptionConstants.NonceLength];
 
-            RandomNumberGenerator.Fill(sessionKey.AsSpan(0, SessionKeyLength));
+            RandomNumberGenerator.Fill(
+                header.AsSpan(
+                    EncryptionConstants.HeaderSessionKeyOffset,
+                    EncryptionConstants.SessionKeyLength
+                )
+            );
             RandomNumberGenerator.Fill(_nonce);
 
-            _aes = new AesGcm(sessionKey.AsSpan(0, SessionKeyLength), TagLength);
-
-            byte[] encryptedTagSize = _rsaPublicKey.Encrypt(
-                BitConverter.GetBytes(TagLength),
-                RSAEncryptionPadding.OaepSHA256
-            );
-            byte[] encryptedNonce = _rsaPublicKey.Encrypt(_nonce, RSAEncryptionPadding.OaepSHA256);
-            byte[] encryptedSessionKey = _rsaPublicKey.Encrypt(
-                sessionKey.AsSpan(0, SessionKeyLength).ToArray(),
-                RSAEncryptionPadding.OaepSHA256
+            _aes = new AesGcm(
+                header.AsSpan(
+                    EncryptionConstants.HeaderSessionKeyOffset,
+                    EncryptionConstants.SessionKeyLength
+                ),
+                EncryptionConstants.TagLength
             );
 
-            byte[] encryptedTagSizeLength = BitConverter.GetBytes(encryptedTagSize.Length);
-            byte[] encryptedNonceLength = BitConverter.GetBytes(encryptedNonce.Length);
-            byte[] encryptedSessionKeyLength = BitConverter.GetBytes(encryptedSessionKey.Length);
+            BitConverter.GetBytes(EncryptionConstants.TagLength).CopyTo(header, 0);
+            _nonce.CopyTo(header, EncryptionConstants.HeaderNonceOffset);
 
-            // Combine all header data and check for markers once
-            int headerUnescapedLength =
-                encryptedTagSize.Length + encryptedNonce.Length + encryptedSessionKey.Length;
-            int maxHeaderSize =
-                headerUnescapedLength + (headerUnescapedLength / _marker.Length) + 1;
-            byte[] finalHeaderBuffer = ArrayPool<byte>.Shared.Rent(maxHeaderSize);
+            byte[] encryptedRsaHeader = _publicKey.Encrypt(
+                header.AsSpan(0, EncryptionConstants.HeaderUnencryptedSize).ToArray(),
+                RSAEncryptionPadding.OaepSHA256
+            );
 
-            try
-            {
-                int unescapedPos = 0;
-                encryptedTagSize.CopyTo(finalHeaderBuffer.AsSpan(unescapedPos));
-                unescapedPos += encryptedTagSize.Length;
-                encryptedNonce.CopyTo(finalHeaderBuffer.AsSpan(unescapedPos));
-                unescapedPos += encryptedNonce.Length;
-                encryptedSessionKey.CopyTo(finalHeaderBuffer.AsSpan(unescapedPos));
-
-                // Fast path: check if escaping is needed
-                Span<byte> unescapedHeader = finalHeaderBuffer.AsSpan(0, headerUnescapedLength);
-                int markerPos = unescapedHeader.IndexOf(_marker);
-
-                int finalHeaderLength =
-                    (markerPos == -1)
-                        ? headerUnescapedLength
-                        : EscapeMarkersInHeader(unescapedHeader, finalHeaderBuffer);
-
-                await _underlyingStream
-                    .WriteAsync(_marker, cancellationToken)
-                    .ConfigureAwait(false);
-                await _underlyingStream
-                    .WriteAsync(encryptedTagSizeLength, cancellationToken)
-                    .ConfigureAwait(false);
-                await _underlyingStream
-                    .WriteAsync(encryptedNonceLength, cancellationToken)
-                    .ConfigureAwait(false);
-                await _underlyingStream
-                    .WriteAsync(encryptedSessionKeyLength, cancellationToken)
-                    .ConfigureAwait(false);
-                await _underlyingStream
-                    .WriteAsync(finalHeaderBuffer.AsMemory(0, finalHeaderLength), cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(finalHeaderBuffer);
-            }
+            await _underlyingStream
+                .WriteAsync(EncryptionConstants.Marker, cancellationToken)
+                .ConfigureAwait(false);
+            await _underlyingStream
+                .WriteAsync(EncryptionConstants.Version, cancellationToken)
+                .ConfigureAwait(false);
+            await _underlyingStream
+                .WriteAsync(encryptedRsaHeader, cancellationToken)
+                .ConfigureAwait(false);
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(sessionKey.AsSpan(0, SessionKeyLength));
-            ArrayPool<byte>.Shared.Return(sessionKey);
-        }
-    }
-
-    /// <summary>
-    /// Escapes marker sequences in the header data and writes the escaped result to the provided buffer.
-    /// The caller should ensure there is a marker to escape first and provide a finalHeaderBuffer that is
-    /// large enough to hold the escaped data (worst case is dataLen + (dataLen / makerLen) + 1).
-    /// </summary>
-    /// <param name="unescapedHeader"></param>
-    /// <param name="finalHeaderBuffer"></param>
-    /// <returns></returns>
-    internal static int EscapeMarkersInHeader(Span<byte> unescapedHeader, byte[] finalHeaderBuffer)
-    {
-        int finalHeaderLength;
-        byte[] tempBuffer = ArrayPool<byte>.Shared.Rent(unescapedHeader.Length);
-        try
-        {
-            unescapedHeader.CopyTo(tempBuffer);
-            finalHeaderLength = WriteEscapedSpan(
-                tempBuffer.AsSpan(0, unescapedHeader.Length),
-                finalHeaderBuffer.AsSpan(0)
+            CryptographicOperations.ZeroMemory(
+                header.AsSpan(0, EncryptionConstants.HeaderUnencryptedSize)
             );
+            ArrayPool<byte>.Shared.Return(header);
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(tempBuffer);
-        }
-
-        return finalHeaderLength;
     }
 
     /// <inheritdoc/>
@@ -445,14 +336,16 @@ public class EncryptedStream : Stream
     }
 
     /// <summary>
-    /// Transforms plaintext data into encrypted format with framing and escaping.
+    /// Transforms plaintext data into encrypted format with framing.
     /// </summary>
     /// <param name="plainText">The plaintext data to encrypt.</param>
-    /// <returns>A tuple containing the rented buffer and the actual length of data written. Caller must return the buffer to ArrayPool.</returns>
+    /// <returns>A tuple containing the rented buffer and the actual length of data written.
+    /// Caller must only write the length and Caller must return the buffer to ArrayPool.
+    /// </returns>
     /// <remarks>
     /// Uses ArrayPool for all buffers to reduce allocations and GC pressure.
-    /// The method performs encryption, adds integrity tags, applies escape sequences,
-    /// and prepends the message length in a single-pass operation without pre-scanning.
+    /// The method performs encryption, adds integrity tags,
+    /// and prepends the message length in a single-pass operation.
     /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown if the aes session was not initialized.</exception>
     private (byte[] Buffer, int Length) Transform(ReadOnlySpan<byte> plainText)
@@ -462,89 +355,36 @@ public class EncryptedStream : Stream
             throw new InvalidOperationException("Encryption session not initialized.");
         }
 
-        // First, encrypt the data
-        int encryptedSize = plainText.Length + TagLength;
+        int encryptedSize = plainText.Length + EncryptionConstants.TagLength;
         byte[] encryptedBuffer = ArrayPool<byte>.Shared.Rent(encryptedSize);
 
         try
         {
             Span<byte> cypherText = encryptedBuffer.AsSpan(0, plainText.Length);
-            Span<byte> hmac = encryptedBuffer.AsSpan(plainText.Length, TagLength);
+            Span<byte> hmac = encryptedBuffer.AsSpan(
+                plainText.Length,
+                EncryptionConstants.TagLength
+            );
 
             _aes.Encrypt(_nonce, plainText, cypherText, hmac);
             _nonce.IncreaseNonce();
 
-            // Fast path: check if escaping is needed
             ReadOnlySpan<byte> encryptedData = encryptedBuffer.AsSpan(0, encryptedSize);
-            int markerPos = encryptedData.IndexOf(_marker);
+            int resultSize = EncryptionConstants.SizeOfInt + encryptedSize;
+            byte[] resultBuffer = ArrayPool<byte>.Shared.Rent(resultSize);
 
-            byte[] resultBuffer;
-            int resultSize;
-
-            if (markerPos == -1) // No markers, no escaping needed
-            {
-                resultSize = LengthPrefixSize + encryptedSize;
-                resultBuffer = ArrayPool<byte>.Shared.Rent(resultSize);
-
-                BitConverter.TryWriteBytes(resultBuffer.AsSpan(0, LengthPrefixSize), encryptedSize);
-                encryptedData.CopyTo(resultBuffer.AsSpan(LengthPrefixSize));
-            }
-            else // Markers found, need to escape
-            {
-                int maxEscapedSize = encryptedSize + (encryptedSize / _marker.Length) + 1;
-                resultBuffer = ArrayPool<byte>.Shared.Rent(LengthPrefixSize + maxEscapedSize);
-
-                int escapedLength = WriteEscapedSpan(
-                    encryptedData,
-                    resultBuffer.AsSpan(LengthPrefixSize)
-                );
-                BitConverter.TryWriteBytes(resultBuffer.AsSpan(0, LengthPrefixSize), escapedLength);
-
-                resultSize = LengthPrefixSize + escapedLength;
-            }
+            BitConverter.TryWriteBytes(
+                resultBuffer.AsSpan(0, EncryptionConstants.SizeOfInt),
+                encryptedSize
+            );
+            encryptedData.CopyTo(resultBuffer.AsSpan(EncryptionConstants.SizeOfInt));
 
             return (resultBuffer, resultSize);
         }
         finally
         {
+            CryptographicOperations.ZeroMemory(encryptedBuffer);
             ArrayPool<byte>.Shared.Return(encryptedBuffer);
         }
-    }
-
-    /// <summary>
-    /// Writes a single span to the destination with escape sequences applied.
-    /// </summary>
-    /// <param name="source">The source data.</param>
-    /// <param name="destination">The destination buffer. Up to the caller to ensure this is large enough to hold the escaped data.</param>
-    /// <returns>Number of bytes written to destination.</returns>
-    internal static int WriteEscapedSpan(ReadOnlySpan<byte> source, Span<byte> destination)
-    {
-        int srcPos = 0;
-        int destPos = 0;
-
-        while (srcPos < source.Length)
-        {
-            // Find next marker occurrence in remaining source
-            int markerPos = source.Slice(srcPos).IndexOf(_marker);
-
-            if (markerPos == -1) // No more markers, copy the rest
-            {
-                source[srcPos..].CopyTo(destination[destPos..]);
-                destPos += source.Length - srcPos;
-                break;
-            }
-
-            // Copy data up to and including the marker
-            int copyLength = markerPos + _marker.Length;
-            source.Slice(srcPos, copyLength).CopyTo(destination[destPos..]);
-            srcPos += copyLength;
-            destPos += copyLength;
-
-            // Add escape byte after the marker
-            destination[destPos] = EscapeMarker;
-            destPos++;
-        }
-
-        return destPos;
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt/EncryptionConstants.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptionConstants.cs
@@ -1,0 +1,15 @@
+namespace Serilog.Sinks.File.Encrypt;
+
+internal static class EncryptionConstants
+{
+    public static readonly byte[] Marker = [0xFF, 0xFF, 0xFF, 0xFF];
+    public static readonly byte[] Version = [0x01, 0x00, 0x00, 0x00];
+    public const int NonceLength = 12; // 96 bits, NIST recommended for AES-GCM
+    public const int SessionKeyLength = 32; // 256 bits for AES-256
+    public const int TagLength = 16; // 128 bits for AES-GCM authentication tag
+    public const int SizeOfInt = sizeof(int);
+    public const int HeaderUnencryptedSize = SizeOfInt + NonceLength + SessionKeyLength;
+    public const int HeaderNonceOffset = SizeOfInt;
+    public const int HeaderSessionKeyOffset = SizeOfInt + NonceLength;
+    public const int MinRsaKeySize = 2048; // Minimum RSA key size in bits for secure encryption
+}

--- a/src/Serilog.Sinks.File.Encrypt/EncryptionUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptionUtils.cs
@@ -33,17 +33,10 @@ public static class EncryptionUtils
     /// AES-GCM encryption requires a unique nonce for each encryption operation.
     /// This method retrieves the current nonce value stored in the last 8 bytes of the data array.
     /// </summary>
-    /// <param name="nonce">Nonce of any length >= 8</param>
+    /// <param name="nonce">Nonce of any length >= 12</param>
     /// <returns>The current nonce counter value.</returns>
-    internal static long GetNonce(this byte[] nonce)
+    private static long GetNonce(this byte[] nonce)
     {
-        ArgumentNullException.ThrowIfNull(nonce, nameof(nonce));
-
-        if (nonce.Length < 8)
-        {
-            throw new ArgumentException("Invalid nonce length", nameof(nonce));
-        }
-
         return BitConverter.ToInt64(nonce, nonce.Length - sizeof(long));
     }
 
@@ -51,17 +44,19 @@ public static class EncryptionUtils
     /// AES-GCM encryption requires a unique nonce for each encryption operation.
     /// This method increments the nonce value stored in the last 8 bytes of the data array.
     /// </summary>
-    /// <param name="nonce">Nonce of any length >= 8</param>
+    /// <param name="nonce">Nonce of any length >= 12</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="nonce"/> is null.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="nonce"/> length is less than 12 bytes.
+    /// </exception>
     internal static void IncreaseNonce(this byte[] nonce)
     {
-        ArgumentNullException.ThrowIfNull(nonce, nameof(nonce));
+        ArgumentNullException.ThrowIfNull(nonce);
+        ArgumentOutOfRangeException.ThrowIfLessThan(nonce.Length, 12);
 
-        if (nonce.Length < 8)
-        {
-            throw new ArgumentException("Invalid nonce length", nameof(nonce));
-        }
-
-        long value = nonce.GetNonce() + 1 % long.MaxValue;
+        long value = nonce.GetNonce() + (1 % long.MaxValue);
         byte[] nonceBytes = BitConverter.GetBytes(value);
         nonceBytes.CopyTo(nonce, nonce.Length - sizeof(long));
     }
@@ -98,7 +93,10 @@ public static class EncryptionUtils
     /// // Use secure storage for private key (Azure Key Vault, etc.)
     /// </code>
     /// </example>
-    public static (string publicKey, string privateKey) GenerateRsaKeyPair(int keySize = 2048, KeyFormat format = KeyFormat.Xml)
+    public static (string publicKey, string privateKey) GenerateRsaKeyPair(
+        int keySize = 2048,
+        KeyFormat format = KeyFormat.Xml
+    )
     {
         using RSA rsa = RSA.Create(keySize);
 
@@ -106,14 +104,14 @@ public static class EncryptionUtils
         {
             KeyFormat.Xml => rsa.ToXmlString(includePrivateParameters: false),
             KeyFormat.Pem => rsa.ExportRSAPublicKeyPem(),
-            _ => throw new NotSupportedException($"Unsupported key format: {format}")
+            _ => throw new NotSupportedException($"Unsupported key format: {format}"),
         };
 
         string privateKey = format switch
         {
             KeyFormat.Xml => rsa.ToXmlString(includePrivateParameters: true),
             KeyFormat.Pem => rsa.ExportRSAPrivateKeyPem(),
-            _ => throw new NotSupportedException($"Unsupported key format: {format}")
+            _ => throw new NotSupportedException($"Unsupported key format: {format}"),
         };
 
         return (publicKey, privateKey);

--- a/src/Serilog.Sinks.File.Encrypt/Models/DecryptionContext.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Models/DecryptionContext.cs
@@ -3,20 +3,13 @@ namespace Serilog.Sinks.File.Encrypt.Models;
 /// <summary>
 /// Represents the current decryption context with active encryption keys
 /// </summary>
-internal class DecryptionContext
+internal class DecryptionContext(int tagLength, byte[] nonce, byte[] sessionKey)
 {
-    public DecryptionContext(int tagLength, byte[] nonce, byte[] sessionKey)
-    {
-        Nonce = nonce;
-        SessionKey = sessionKey;
-        TagLength = tagLength;
-    }
+    public int TagLength { get; } = tagLength;
 
-    public int TagLength { get; init; }
+    public byte[] SessionKey { get; } = sessionKey;
 
-    public byte[] SessionKey { get; init; }
-
-    public byte[] Nonce { get; private set; }
+    public byte[] Nonce { get; } = nonce;
 
     public static DecryptionContext Empty => new(0, [], []);
 

--- a/src/Serilog.Sinks.File.Encrypt/Models/HeaderSection.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Models/HeaderSection.cs
@@ -3,4 +3,4 @@ namespace Serilog.Sinks.File.Encrypt.Models;
 /// <summary>
 /// Represents a parsed header section from the encrypted file
 /// </summary>
-internal record HeaderSection(byte[] TagLength, byte[] Nonce, byte[] SessionKey);
+internal record HeaderSection(byte[] EncryptedHeader);

--- a/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
+++ b/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
@@ -10,12 +10,6 @@ namespace Serilog.Sinks.File.Encrypt;
 /// </summary>
 internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposable
 {
-    // csharpier-ignore-start
-    private static readonly byte[] _marker = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01];
-    private static readonly byte _escapeMarker = 0x00;
-    // csharpier-ignore-end
-    private static readonly int _markerLength = _marker.Length;
-
     private readonly Stream _inputStream;
     private readonly RSA _rsa;
     private readonly StreamingOptions _options;
@@ -24,15 +18,17 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     private bool _disposed;
     private bool _hasFoundValidHeader;
 
+    private int EncryptedHeaderSize => _rsa.KeySize / 8;
+
     public StreamingEncryptedFileReader(
         Stream inputStream,
-        string rsaPrivateKey,
+        string privateKey,
         StreamingOptions options
     )
     {
         _inputStream = inputStream;
         _rsa = RSA.Create();
-        _rsa.FromString(rsaPrivateKey);
+        _rsa.FromString(privateKey);
         _options = options;
         _context = DecryptionContext.Empty;
         _hasFoundValidHeader = false;
@@ -198,9 +194,7 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// <summary>
     /// Processes a header section to extract encryption keys
     /// </summary>
-    private async Task ProcessHeaderSectionAsync(
-        CancellationToken cancellationToken
-    )
+    private async Task ProcessHeaderSectionAsync(CancellationToken cancellationToken)
     {
         HeaderSection header = await ReadHeaderSectionAsync(cancellationToken);
 
@@ -232,34 +226,25 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// <summary>
     /// Reads header section data from the input stream
     /// </summary>
-    private async Task<HeaderSection> ReadHeaderSectionAsync(
-        CancellationToken cancellationToken
-    )
+    /// <exception cref="InvalidOperationException"></exception>
+    private async Task<HeaderSection> ReadHeaderSectionAsync(CancellationToken cancellationToken)
     {
         // skip the header marker
-        _inputStream.Position += _markerLength;
+        _inputStream.Position += EncryptionConstants.SizeOfInt;
 
         // Read the tag, nonce, and session key lengths
-        byte[] tagLengthBytes = new byte[sizeof(int)];
-        byte[] nonceLengthBytes = new byte[sizeof(int)];
-        byte[] sessionKeyLengthBytes = new byte[sizeof(int)];
-        await _inputStream.ReadExactlyAsync(tagLengthBytes, cancellationToken);
-        await _inputStream.ReadExactlyAsync(nonceLengthBytes, cancellationToken);
-        await _inputStream.ReadExactlyAsync(sessionKeyLengthBytes, cancellationToken);
-
-        int tagBytesLength = BitConverter.ToInt32(tagLengthBytes, 0);
-        int nonceLength = BitConverter.ToInt32(nonceLengthBytes, 0);
-        int sessionKeyLength = BitConverter.ToInt32(sessionKeyLengthBytes, 0);
-
-        byte[] headerSection = new byte[tagBytesLength + nonceLength + sessionKeyLength];
-
-        await _inputStream.ReadExactlyAsync(headerSection, cancellationToken);
-
-        Unescape(ref headerSection);
-
-        return new HeaderSection(headerSection[..tagBytesLength],
-            headerSection[tagBytesLength..^nonceLength],
-            headerSection[^sessionKeyLength..]);
+        byte[] versionBuffer = new byte[EncryptionConstants.Version.Length];
+        await _inputStream.ReadExactlyAsync(versionBuffer, cancellationToken);
+        if (!versionBuffer.SequenceEqual(EncryptionConstants.Version))
+        {
+            // Can refactor to support multiple versions in the future.
+            throw new InvalidOperationException(
+                $"Unsupported stream version: {BitConverter.ToString(versionBuffer)}"
+            );
+        }
+        byte[] encryptedHeader = new byte[EncryptedHeaderSize];
+        await _inputStream.ReadExactlyAsync(encryptedHeader, cancellationToken);
+        return new HeaderSection(encryptedHeader);
     }
 
     /// <summary>
@@ -267,7 +252,7 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// </summary>
     private async Task<MessageSection> ReadMessageSectionAsync(CancellationToken cancellationToken)
     {
-        byte[] lengthBytes = new byte[4];
+        byte[] lengthBytes = new byte[EncryptionConstants.SizeOfInt];
         await _inputStream.ReadExactlyAsync(lengthBytes, cancellationToken);
         int messageLength = BitConverter.ToInt32(lengthBytes, 0);
         return new MessageSection(messageLength);
@@ -278,13 +263,23 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// </summary>
     private DecryptionContext DecryptKeys(HeaderSection header)
     {
-        byte[] tagLengthBytes = _rsa.Decrypt(header.TagLength, RSAEncryptionPadding.OaepSHA256);
-        byte[] nonce = _rsa.Decrypt(header.Nonce, RSAEncryptionPadding.OaepSHA256);
-        byte[] sessionkey = _rsa.Decrypt(header.SessionKey, RSAEncryptionPadding.OaepSHA256);
+        byte[] decryptedHeader = _rsa.Decrypt(
+            header.EncryptedHeader,
+            RSAEncryptionPadding.OaepSHA256
+        );
+        byte[] tagLengthBytes = decryptedHeader[..EncryptionConstants.SizeOfInt];
+        byte[] nonce = decryptedHeader[
+            EncryptionConstants.SizeOfInt..(EncryptionConstants.HeaderSessionKeyOffset)
+        ];
+        byte[] sessionKey = decryptedHeader[
+            (EncryptionConstants.HeaderSessionKeyOffset)..(
+                EncryptionConstants.HeaderSessionKeyOffset + EncryptionConstants.SessionKeyLength
+            )
+        ];
 
         int tag = BitConverter.ToInt32(tagLengthBytes);
 
-        return new DecryptionContext(tag, nonce, sessionkey);
+        return new DecryptionContext(tag, nonce, sessionKey);
     }
 
     /// <summary>
@@ -297,12 +292,17 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     {
         byte[] message = new byte[messageLength];
         await _inputStream.ReadExactlyAsync(message, cancellationToken);
-        Unescape(ref message);
 
         byte[] cypherText = message[..^_context.TagLength];
         byte[] hmac = message[^_context.TagLength..];
 
-        string plainText = DecryptData(cypherText, _context.SessionKey, _context.Nonce, hmac, _context.TagLength);
+        string plainText = DecryptData(
+            cypherText,
+            _context.SessionKey,
+            _context.Nonce,
+            hmac,
+            _context.TagLength
+        );
 
         _context.Nonce.IncreaseNonce();
 
@@ -444,44 +444,16 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     // Helper methods
     private async Task<byte[]?> ReadMarkerBufferAsync(CancellationToken cancellationToken)
     {
-        byte[] markerBuffer = new byte[_markerLength];
+        byte[] markerBuffer = new byte[EncryptionConstants.SizeOfInt];
         int bytesRead = await _inputStream.ReadAsync(markerBuffer, cancellationToken);
-        _inputStream.Position -= bytesRead != _markerLength ? 0 : _markerLength;
-        return bytesRead == _markerLength ? markerBuffer : null;
-    }
-
-    /// <summary>
-    /// Unescapes occurrences of the specified marker in the data by removing in-place the escape byte after each occurrence.
-    /// </summary>
-    /// <param name="data">The data to unescape.</param>
-    private void Unescape(ref byte[] data)
-    {
-        byte[] markerWithEscape = new byte[_marker.Length + 1];
-
-        markerWithEscape[0] = _marker[0];
-        markerWithEscape[1] = _escapeMarker;
-        Array.Copy(_marker, 1, markerWithEscape, 2, _marker.Length - 1);
-
-        while (true)
-        {
-            int pos = data.IndexOf(markerWithEscape);
-
-            if (pos != -1)
-            {
-                Array.Copy(data, pos + 2, data, pos + 1, data.Length - (pos + 2));
-                Array.Resize(ref data, data.Length - 1);
-            }
-            else
-            {
-                break;
-            }
-        }
+        _inputStream.Position -= bytesRead != EncryptionConstants.SizeOfInt ? 0 : bytesRead;
+        return bytesRead == EncryptionConstants.SizeOfInt ? markerBuffer : null;
     }
 
     private bool IsEndOfStream() => _inputStream.Position >= _inputStream.Length;
 
     private static bool IsHeaderMarker(byte[] markerBuffer) =>
-        markerBuffer.SequenceEqual(_marker);
+        markerBuffer.SequenceEqual(EncryptionConstants.Marker);
 
     private async Task HandleErrorAsync(
         ChannelWriter<IDecryptionChunk> writer,
@@ -501,13 +473,13 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     private async Task TryRecoverAsync(CancellationToken cancellationToken)
     {
         // Try to find the next valid marker
-        byte[] searchBuffer = new byte[_markerLength];
+        byte[] searchBuffer = new byte[EncryptionConstants.SizeOfInt];
 
-        while (_inputStream.Position < _inputStream.Length - _markerLength)
+        while (_inputStream.Position < _inputStream.Length - EncryptionConstants.SizeOfInt)
         {
             // Read potential marker
             int bytesRead = await _inputStream.ReadAsync(searchBuffer, cancellationToken);
-            if (bytesRead < _markerLength)
+            if (bytesRead < EncryptionConstants.SizeOfInt)
             {
                 break;
             }
@@ -516,12 +488,12 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
             if (IsHeaderMarker(searchBuffer))
             {
                 // Move back to start of marker
-                _inputStream.Position -= _markerLength;
+                _inputStream.Position -= EncryptionConstants.SizeOfInt;
                 return;
             }
 
             // Move back and advance by 1 byte to continue searching
-            _inputStream.Position -= _markerLength - 1;
+            _inputStream.Position -= EncryptionConstants.SizeOfInt - 1;
         }
     }
 

--- a/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
+++ b/src/Serilog.Sinks.File.Encrypt/StreamingEncryptedFileReader.cs
@@ -181,13 +181,20 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
         }
         else if (_context.HasKeys)
         {
-            await ProcessBodySectionAsync(writer, cancellationToken);
+            try
+            {
+                await ProcessBodySectionAsync(writer, cancellationToken);
+            }
+            catch (InvalidOperationException)
+            {
+                _inputStream.Position++; // Move forward assuming corrupted data
+            }
         }
         else
         {
             // move the stream position forward by 1 byte to continue searching
             // for the first valid header marker
-            _inputStream.Position += 1;
+            _inputStream.Position++;
         }
     }
 
@@ -250,12 +257,31 @@ internal sealed class StreamingEncryptedFileReader : IDisposable, IAsyncDisposab
     /// <summary>
     /// Reads body section metadata from the input stream
     /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
     private async Task<MessageSection> ReadMessageSectionAsync(CancellationToken cancellationToken)
     {
         byte[] lengthBytes = new byte[EncryptionConstants.SizeOfInt];
-        await _inputStream.ReadExactlyAsync(lengthBytes, cancellationToken);
-        int messageLength = BitConverter.ToInt32(lengthBytes, 0);
-        return new MessageSection(messageLength);
+        try
+        {
+            await _inputStream.ReadExactlyAsync(lengthBytes, cancellationToken);
+            int messageLength = BitConverter.ToInt32(lengthBytes, 0);
+            if (messageLength > 0) // not sure if this should allow zero-length messages
+            {
+                return new MessageSection(messageLength);
+            }
+
+            _inputStream.Position -= lengthBytes.Length;
+            throw new InvalidOperationException(
+                $"Invalid message length: {messageLength} at position {_inputStream.Position - EncryptionConstants.SizeOfInt}"
+            );
+        }
+        catch (EndOfStreamException ex)
+        {
+            throw new InvalidOperationException(
+                "Unexpected end of stream while reading message length.",
+                ex
+            );
+        }
     }
 
     /// <summary>

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptedStreamAsyncTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptedStreamAsyncTests.cs
@@ -37,11 +37,7 @@ public sealed class EncryptedStreamAsyncTests : EncryptionTestBase
         string[] messages = ["First async message", "Second async message", "Third async message"];
 
         // Act - Use async stream creation which calls FlushAsync
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         string decrypted = await DecryptStreamToStringAsync(
             encryptedStream,
@@ -89,17 +85,8 @@ public sealed class EncryptedStreamAsyncTests : EncryptionTestBase
         string largeMessage = new('X', 10000); // 10KB of X's
 
         // Act - Use async stream creation which calls FlushAsync
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            largeMessage,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
-
-        string decrypted = await DecryptStreamToStringAsync(
-            encryptedStream,
-            RsaKeyPair.privateKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(largeMessage);
+        string decrypted = await DecryptStreamToStringAsync(encryptedStream);
 
         // Assert
         decrypted.ShouldBe(largeMessage);
@@ -112,11 +99,7 @@ public sealed class EncryptedStreamAsyncTests : EncryptionTestBase
         string[] messages = ["Chunk 1", "Chunk 2", "Chunk 3", "Chunk 4", "Chunk 5"];
 
         // Act - Each message gets its own flush in CreateEncryptedStreamAsync
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         string decrypted = await DecryptStreamToStringAsync(
             encryptedStream,
@@ -139,8 +122,7 @@ public sealed class EncryptedStreamAsyncTests : EncryptionTestBase
         // Act - Create stream with a valid token
         MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
             TestMessage,
-            RsaKeyPair.publicKey,
-            cts.Token
+            cancellationToken: cts.Token
         );
 
         // Assert - Should complete successfully
@@ -159,23 +141,11 @@ public sealed class EncryptedStreamAsyncTests : EncryptionTestBase
 # pragma warning disable S6966 // Suppress "Async method name should end with 'Async'" for test purpose
         MemoryStream syncStream = CreateEncryptedStream(TestMessage, RsaKeyPair.publicKey);
 # pragma warning restore S6966
-        string syncDecrypted = await DecryptStreamToStringAsync(
-            syncStream,
-            RsaKeyPair.privateKey,
-            TestContext.Current.CancellationToken
-        );
+        string syncDecrypted = await DecryptStreamToStringAsync(syncStream);
 
         // Create one with async FlushAsync
-        MemoryStream asyncStream = await CreateEncryptedStreamAsync(
-            TestMessage,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
-        string asyncDecrypted = await DecryptStreamToStringAsync(
-            asyncStream,
-            RsaKeyPair.privateKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream asyncStream = await CreateEncryptedStreamAsync(TestMessage);
+        string asyncDecrypted = await DecryptStreamToStringAsync(asyncStream);
 
         // Assert - Both should decrypt to the same original message
         asyncDecrypted.ShouldBe(syncDecrypted);

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptedStreamTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptedStreamTests.cs
@@ -105,53 +105,6 @@ public class EncryptedStreamTests
     }
 
     [Fact]
-    public void EscapeMarkersInHeader_EscapesMarkersCorrectly()
-    {
-        // Arrange
-        byte[] header = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01];
-        byte[] expectedEscaped = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01, 0x00];
-        byte[] finalBuffer = new byte[expectedEscaped.Length];
-
-        // Act
-        int bytesWritten = EncryptedStream.EscapeMarkersInHeader(header.AsSpan(), finalBuffer);
-
-        // Assert
-        bytesWritten.ShouldBeEquivalentTo(expectedEscaped.Length);
-        finalBuffer.ShouldBeEquivalentTo(expectedEscaped);
-    }
-
-    [Fact]
-    public void WriteEscapedSpan_EscapesMarkerCorrectly()
-    {
-        // Arrange
-        byte[] input = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01];
-        byte[] expectedEscaped = [0xFF, 0xFE, 0x4C, 0x4F, 0x47, 0x48, 0x44, 0x00, 0x01, 0x00];
-
-        // Act
-        Span<byte> actual = new byte[expectedEscaped.Length];
-        EncryptedStream.WriteEscapedSpan(input, actual);
-
-        // Assert
-        actual.ToArray().ShouldBeEquivalentTo(expectedEscaped);
-    }
-
-    [Theory]
-    [InlineData(
-        new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 },
-        Label = "Long enough for markers, but no markers"
-    )]
-    [InlineData(new byte[] { 0x10, 0x20, 0x30, 0x40 }, Label = "Not long enough for markers")]
-    public void WriteEscapedSpan_NoMarkers_DoesNotAlterData(byte[] input)
-    {
-        // Act
-        Span<byte> actual = new byte[input.Length];
-        EncryptedStream.WriteEscapedSpan(input, actual);
-
-        // Assert
-        actual.ToArray().ShouldBeEquivalentTo(input);
-    }
-
-    [Fact]
     public void Ctor_NullStream_ThrowsArgumentNullException()
     {
         // Arrange

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptionTestBase.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptionTestBase.cs
@@ -54,23 +54,24 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
     /// </summary>
     protected async Task<MemoryStream> CreateEncryptedStreamAsync(
         string[] messages,
-        string publicKey,
-        CancellationToken cancellationToken = default
+        string? publicKey = null,
+        CancellationToken? cancellationToken = null
     )
     {
+        CancellationToken ct = cancellationToken ?? TestContext.Current.CancellationToken;
         MemoryStream memoryStream = new();
         _streamsToDispose.Add(memoryStream);
 
         using RSA rsa = RSA.Create();
-        rsa.FromXmlString(publicKey);
+        rsa.FromXmlString(publicKey ?? RsaKeyPair.publicKey);
 
         // Create EncryptedStream but don't dispose it - disposing would close the underlying MemoryStream
         EncryptedStream encryptedStream = new(memoryStream, rsa);
 
         foreach (byte[] message in messages.Select(m => Encoding.UTF8.GetBytes(m)))
         {
-            await encryptedStream.WriteAsync(message, cancellationToken);
-            await encryptedStream.FlushAsync(cancellationToken);
+            await encryptedStream.WriteAsync(message, ct);
+            await encryptedStream.FlushAsync(ct);
         }
 
         // Don't dispose encryptedStream here - let it be garbage collected
@@ -85,11 +86,28 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
     /// </summary>
     protected async Task<MemoryStream> CreateEncryptedStreamAsync(
         string message,
-        string publicKey,
-        CancellationToken cancellationToken = default
+        string? publicKey = null,
+        CancellationToken? cancellationToken = null
     )
     {
         return await CreateEncryptedStreamAsync([message], publicKey, cancellationToken);
+    }
+
+    protected async Task<MemoryStream> CreateAppendedMemoryStream(
+        MemoryStream memoryStream,
+        string message,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using RSA rsa = RSA.Create();
+        rsa.FromXmlString(RsaKeyPair.publicKey);
+        memoryStream.Position = memoryStream.Length;
+        EncryptedStream encryptedStream = new(memoryStream, rsa);
+        byte[] messageBytes = Encoding.UTF8.GetBytes(message);
+        await encryptedStream.WriteAsync(messageBytes, cancellationToken);
+        await encryptedStream.FlushAsync(cancellationToken);
+        memoryStream.Position = 0;
+        return memoryStream;
     }
 
     /// <summary>
@@ -117,9 +135,9 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
     /// </summary>
     protected async Task<string> EncryptAndDecryptAsync(
         string[] messages,
-        string publicKey,
-        string privateKey,
-        CancellationToken cancellationToken = default
+        string? publicKey = null,
+        string? privateKey = null,
+        CancellationToken? cancellationToken = null
     )
     {
         MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
@@ -135,9 +153,9 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
     /// </summary>
     protected async Task<string> EncryptAndDecryptAsync(
         string message,
-        string publicKey,
-        string privateKey,
-        CancellationToken cancellationToken = default
+        string? publicKey = null,
+        string? privateKey = null,
+        CancellationToken? cancellationToken = null
     )
     {
         return await EncryptAndDecryptAsync([message], publicKey, privateKey, cancellationToken);
@@ -148,22 +166,23 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
     /// </summary>
     protected async Task<string> DecryptStreamToStringAsync(
         Stream inputStream,
-        string privateKey,
-        CancellationToken cancellationToken = default
+        string? privateKey = null,
+        CancellationToken? cancellationToken = null
     )
     {
+        CancellationToken ct = cancellationToken ?? TestContext.Current.CancellationToken;
         MemoryStream outputStream = CreateMemoryStream();
 
         await EncryptionUtils.DecryptLogFileAsync(
             inputStream,
             outputStream,
-            privateKey,
-            cancellationToken: cancellationToken
+            privateKey ?? RsaKeyPair.privateKey,
+            cancellationToken: ct
         );
 
         outputStream.Position = 0;
         using StreamReader reader = new(outputStream, leaveOpen: true);
-        return await reader.ReadToEndAsync(cancellationToken);
+        return await reader.ReadToEndAsync(ct);
     }
 
     /// <summary>
@@ -171,24 +190,25 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
     /// </summary>
     protected async Task<string> DecryptStreamToStringAsync(
         Stream inputStream,
-        string privateKey,
         StreamingOptions options,
-        CancellationToken cancellationToken = default
+        string? privateKey = null,
+        CancellationToken? cancellationToken = null
     )
     {
+        CancellationToken ct = cancellationToken ?? TestContext.Current.CancellationToken;
         MemoryStream outputStream = CreateMemoryStream();
 
         await EncryptionUtils.DecryptLogFileAsync(
             inputStream,
             outputStream,
-            privateKey,
+            privateKey ?? RsaKeyPair.privateKey,
             options,
-            cancellationToken
+            ct
         );
 
         outputStream.Position = 0;
         using StreamReader reader = new(outputStream, leaveOpen: true);
-        return await reader.ReadToEndAsync(cancellationToken);
+        return await reader.ReadToEndAsync(ct);
     }
 
     /// <summary>
@@ -199,6 +219,27 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
         byte[] corrupted = new byte[data.Length];
         Array.Copy(data, corrupted, data.Length);
         corrupted[position] ^= 0xFF; // Flip all bits at position
+        return corrupted;
+    }
+
+    /// <summary>
+    /// Corrupts data by inserting specific marker bytes at the given position
+    /// </summary>
+    /// <param name="data">The data to corrupt</param>
+    /// <param name="position">The position to insert the marker</param>
+    /// <param name="marker">The marker to insert</param>
+    /// <returns>
+    /// The corrupted data with the marker inserted at the specified position
+    /// </returns>
+    protected static byte[] CorruptDataAddingMarker(byte[] data, byte[] marker, int position)
+    {
+        byte[] corrupted = new byte[data.Length];
+        Array.Copy(data, corrupted, data.Length);
+        // Insert marker at position
+        for (int i = 0; i < marker.Length && (position + i) < corrupted.Length; i++)
+        {
+            corrupted[position + i] = marker[i];
+        }
         return corrupted;
     }
 

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
@@ -9,12 +9,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
     {
         // Arrange & Act
         const string TestMessage = "Test log message";
-        string result = await EncryptAndDecryptAsync(
-            TestMessage,
-            RsaKeyPair.publicKey,
-            RsaKeyPair.privateKey,
-            TestContext.Current.CancellationToken
-        );
+        string result = await EncryptAndDecryptAsync(TestMessage);
 
         // Assert
         Assert.Equal(TestMessage, result);
@@ -27,12 +22,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         string[] messages = ["First message", "Second message", "Third message"];
 
         // Act
-        string result = await EncryptAndDecryptAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            RsaKeyPair.privateKey,
-            TestContext.Current.CancellationToken
-        );
+        string result = await EncryptAndDecryptAsync(messages);
 
         // Assert
         string expected = string.Join("", messages);
@@ -51,19 +41,10 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             ContinueOnError = false,
         };
 
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            TestMessage,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(TestMessage);
 
         // Act
-        string result = await DecryptStreamToStringAsync(
-            encryptedStream,
-            RsaKeyPair.privateKey,
-            customOptions,
-            TestContext.Current.CancellationToken
-        );
+        string result = await DecryptStreamToStringAsync(encryptedStream, customOptions);
 
         // Assert
         Assert.Equal(TestMessage, result);
@@ -74,11 +55,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
     {
         // Arrange
         string[] messages = ["Good message 1", "Good message 2"];
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
@@ -86,14 +63,56 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 
         // Act
-        string result = await DecryptStreamToStringAsync(
-            corruptedStream,
-            RsaKeyPair.privateKey,
-            TestContext.Current.CancellationToken
-        );
+        string result = await DecryptStreamToStringAsync(corruptedStream);
 
         // Assert
         result.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Special case test where corruption introduces a marker in parts of that data for the 2nd message.
+    /// and ensures decryption continues past it.
+    /// </summary>
+    [Theory]
+    [InlineData(299)] // Corrupt the length so it is a marker, but the data is still intact
+    [InlineData(300)] // Corrupt part of the length and data.
+    [InlineData(301)] // Corrupt part of the length and data.
+    [InlineData(302)] // Corrupt part of the length and data.
+    [InlineData(303)] // Corrupt the data
+    [InlineData(305)] // Corrupt the data more.
+    [InlineData(310)] // Corrupt the data and more.
+    [InlineData(320)] // Corrupt the data and more and more.
+    public async Task DecryptLogFileAsync_WithCorruptedMessageLength_ContinuesOnError(
+        int corruptionOffset
+    )
+    {
+        // Arrange - Do not change message sizes or the marker will not be in the correct offsets for each test.
+        string[] messages = ["Good message 1\n", "Good message 2\n"];
+
+        // create a session with 2 messages.
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
+
+        // Append a new session with a message.
+        encryptedStream = await CreateAppendedMemoryStream(
+            encryptedStream,
+            "Appended message",
+            TestContext.Current.CancellationToken
+        );
+
+        // Corrupt part of the first session with a marker that corrupts the length of the 2nd message.
+        byte[] fileBytes = encryptedStream.ToArray();
+        byte[] corrupted = CorruptDataAddingMarker(
+            fileBytes,
+            EncryptionConstants.Marker,
+            corruptionOffset
+        );
+        MemoryStream corruptedStream = CreateMemoryStream(corrupted);
+
+        // Act
+        string result = await DecryptStreamToStringAsync(corruptedStream);
+
+        // Assert we still got message 1 and message 2
+        result.ShouldBe("Good message 1\nAppended message");
     }
 
     [Fact]
@@ -107,11 +126,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             ErrorHandlingMode = ErrorHandlingMode.Skip,
         };
 
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
@@ -119,12 +134,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 
         // Act
-        string result = await DecryptStreamToStringAsync(
-            corruptedStream,
-            RsaKeyPair.privateKey,
-            skipErrorOptions,
-            TestContext.Current.CancellationToken
-        );
+        string result = await DecryptStreamToStringAsync(corruptedStream, skipErrorOptions);
 
         // Assert
         result.ShouldBeEmpty();
@@ -141,11 +151,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             ErrorHandlingMode = ErrorHandlingMode.WriteInline,
         };
 
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
@@ -153,12 +159,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 
         // Act
-        string result = await DecryptStreamToStringAsync(
-            corruptedStream,
-            RsaKeyPair.privateKey,
-            writeInlineOptions,
-            TestContext.Current.CancellationToken
-        );
+        string result = await DecryptStreamToStringAsync(corruptedStream, writeInlineOptions);
 
         // Assert
         result.ShouldContain("[DECRYPTION ERROR");
@@ -177,11 +178,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             ErrorLogPath = errorLogPath,
         };
 
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
@@ -189,12 +186,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         MemoryStream corruptedStream = CreateMemoryStream(corrupted);
 
         // Act
-        string result = await DecryptStreamToStringAsync(
-            corruptedStream,
-            RsaKeyPair.privateKey,
-            errorLogOptions,
-            TestContext.Current.CancellationToken
-        );
+        string result = await DecryptStreamToStringAsync(corruptedStream, errorLogOptions);
 
         // Assert
         result.ShouldBeEmpty();
@@ -226,11 +218,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             ErrorHandlingMode = ErrorHandlingMode.ThrowException,
         };
 
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         // Corrupt part of the stream
         byte[] fileBytes = encryptedStream.ToArray();
@@ -239,12 +227,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
 
         // Act & Assert
         await Assert.ThrowsAsync<CryptographicException>(async () =>
-            await DecryptStreamToStringAsync(
-                corruptedStream,
-                RsaKeyPair.privateKey,
-                throwExceptionOptions,
-                TestContext.Current.CancellationToken
-            )
+            await DecryptStreamToStringAsync(corruptedStream, throwExceptionOptions)
         );
     }
 
@@ -259,19 +242,10 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
             ErrorHandlingMode = ErrorHandlingMode.ThrowException,
         };
 
-        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(
-            messages,
-            RsaKeyPair.publicKey,
-            TestContext.Current.CancellationToken
-        );
+        MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
         // Act - should succeed without throwing
-        string result = await DecryptStreamToStringAsync(
-            encryptedStream,
-            RsaKeyPair.privateKey,
-            throwExceptionOptions,
-            TestContext.Current.CancellationToken
-        );
+        string result = await DecryptStreamToStringAsync(encryptedStream, throwExceptionOptions);
 
         // Assert
         string expected = string.Join("", messages);


### PR DESCRIPTION
clean up sensitive memory when returning buffer to pool for the header (session key + nonce)

closes #44 

Removes the need for escape/unescape logic
Remove the size of things not needed.
Add version after the marker for future use.

Going to do more testing and benchmarking, but the memory usage on this should be hardly any more than unencrypted now.

### Performance Improvements in Encrypted Stream Implementation

This introduces a no-escape refactor for AES-GCM encryption in the stream sink, significantly improving performance and memory efficiency compared to the original escaping implementation.

#### Encrypted Stream

##### Key Gains over Escaping

- **Performance:** Nearly 3x speedup for encrypted writes across all buffer sizes compared to escaping.
- **Memory:** ~20-30% reduction in allocations across all buffer sizes.

#### Full File Sink

##### Key Gains over Escaping
- **Performance:** a wash
- **Memory:** Reductions in allocation, but ~20% better GC
