### PR TITLE
Removing recursive option

### DIFF
--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
@@ -30,11 +30,10 @@ public sealed class DecryptCommand(
     {
         /// <summary>
         /// The path to an encrypted log file or directory containing encrypted log files.
-        /// Supports glob patterns like *.log
         /// </summary>
         [CommandArgument(0, "<PATH>")]
         [Description(
-            "Path to encrypted log file, directory (uses *.log pattern), or glob pattern (e.g., *.log)"
+            @"Path to encrypted log file, for a directory append <PATH>\*.log or <PATH>\*.txt (Not recursive)"
         )]
         public string InputPath { get; init; } = string.Empty;
 
@@ -53,14 +52,6 @@ public sealed class DecryptCommand(
             "Output directory or file path (default: adds .decrypted to original filename)"
         )]
         public string? OutputPath { get; init; }
-
-        /// <summary>
-        /// Process directories recursively.
-        /// </summary>
-        [CommandOption("-r|--recursive")]
-        [Description("Process directories recursively")]
-        [DefaultValue(false)]
-        public bool Recursive { get; init; }
 
         /// <summary>
         /// Fail immediately on first decryption error instead of continuing with remaining files.
@@ -83,9 +74,8 @@ public sealed class DecryptCommand(
     }
 
     private bool IsFile { get; set; }
-    private bool IsDirectory { get; set; }
     private bool IsGlobPattern { get; set; }
-    private bool IsValidInput => IsFile || IsDirectory || IsGlobPattern;
+    private bool IsValidInput => IsFile || IsGlobPattern;
 
     private ILogger? _logger;
 
@@ -105,14 +95,20 @@ public sealed class DecryptCommand(
             );
         }
 
-        // Check if settings.InputPath is a valid file, directory, or glob pattern
+        if (fileSystem.Directory.Exists(settings.InputPath))
+        {
+            return ValidationResult.Error(
+                "✗ Error: Input path cannot be a directory. Please specify a file or add a pattern (<PATH>\\*.log) to select files within the directory."
+            );
+        }
+
+        // Check if settings.InputPath is a valid file or directory with pattern
         IsFile = fileSystem.File.Exists(settings.InputPath);
-        IsDirectory = fileSystem.Directory.Exists(settings.InputPath);
         IsGlobPattern = settings.InputPath.Contains('*') || settings.InputPath.Contains('?');
         if (!IsValidInput)
         {
             return ValidationResult.Error(
-                $"✗ Error: Input path '{settings.InputPath}' is not a valid file, directory, or glob pattern."
+                $"✗ Error: Input path '{settings.InputPath}' is not a valid file or directory with pattern."
             );
         }
 
@@ -142,11 +138,7 @@ public sealed class DecryptCommand(
                 cancellationToken
             );
 
-            // Determine if input is a file, directory, or pattern
-            IReadOnlyList<string> filesToDecrypt = inputResolver.ResolveFiles(
-                settings.InputPath,
-                settings.Recursive
-            );
+            IReadOnlyList<string> filesToDecrypt = inputResolver.ResolveFiles(settings.InputPath);
 
             if (filesToDecrypt.Count == 0)
             {

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
@@ -30,24 +30,25 @@ public static class CommandAppConfiguration
     {
         const string PrivateKey = "private_key.xml";
         const string Decrypt = "decrypt";
+        const string Generate = "generate";
 
         return c =>
         {
             c.SetApplicationName("serilog-encrypt");
-            c.AddCommand<GenerateCommand>("generate")
+            c.AddCommand<GenerateCommand>(Generate)
                 .WithDescription("Generate a new RSA key pair for log encryption")
-                .WithExample("generate", "--output", "./keys");
+                .WithExample(Generate, "--output", "./keys")
+                .WithExample(Generate, "-o", "./keys", "-k", "4096")
+                .WithExample(Generate, "-o", "./keys", "-f", "Pem");
 
             c.AddCommand<DecryptCommand>(Decrypt)
                 .WithDescription("Decrypt encrypted log files using an RSA private key")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey)
-                .WithExample(Decrypt, "./logs", "-k", PrivateKey)
                 .WithExample(Decrypt, "*.log", "-k", PrivateKey)
                 .WithExample(Decrypt, "logs/*.txt", "-k", PrivateKey)
-                .WithExample(Decrypt, "./logs", "-k", PrivateKey, "-r")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "-o", "decrypted.log")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--strict")
-                .WithExample(Decrypt, "./logs", "-k", PrivateKey, "--audit-log", "audit.log");
+                .WithExample(Decrypt, "./logs/*.log", "-k", PrivateKey, "--audit-log", "audit.log");
             c.ValidateExamples();
         };
     }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/IInputResolver.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/IInputResolver.cs
@@ -1,15 +1,14 @@
 namespace Serilog.Sinks.File.Encrypt.Cli;
 
 /// <summary>
-/// Service interface for resolving file paths from user input. This allows the application to support various input formats, such as single files, directories, and glob patterns, while abstracting away the underlying file system operations. Implementations of this interface can handle the logic for parsing the input path and returning a list of file paths that match the criteria specified by the user.
+/// Service interface for resolving file paths from user input. This allows the application to support various input formats, such as single files or directories with glob patterns, while abstracting away the underlying file system operations. Implementations of this interface can handle the logic for parsing the input path and returning a list of file paths that match the criteria specified by the user.
 /// </summary>
 public interface IInputResolver
 {
     /// <summary>
-    /// Resolves the input path to a list of file paths. The input path can be a single file, a directory, or a glob pattern. If the input path is a directory and recursive is true, all files in the directory and its subdirectories will be included.
+    /// Resolves the input path to a list of file paths. The input path can be a single file or directory with a glob pattern.
     /// </summary>
-    /// <param name="inputPath">The input path to resolve. Can be a single file, a directory, or a glob pattern.</param>
-    /// <param name="recursive">Whether to include files in subdirectories if the input path is a directory.</param>
+    /// <param name="inputPath">The input path to resolve.</param>
     /// <returns></returns>
-    IReadOnlyList<string> ResolveFiles(string inputPath, bool recursive);
+    IReadOnlyList<string> ResolveFiles(string inputPath);
 }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/IOutputResolver.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/IOutputResolver.cs
@@ -11,10 +11,10 @@ public interface IOutputResolver
     /// Resolves the output file path for a given input file.
     /// </summary>
     /// <param name="inputFile">The specific input file being processed.</param>
-    /// <param name="inputPath">The original input path supplied by the user (file, directory, or glob pattern).
+    /// <param name="inputPath">The original input path supplied by the user.
     /// Used to determine whether the operation is single-file or multi-file.</param>
     /// <param name="outputPath">
-    /// The output path specified by the user, or <see langword="null"/> to use the default behaviour
+    /// The output path specified by the user, or <see langword="null"/> to use the default behavior
     /// (append <c>.decrypted</c> before the extension in the same directory as the input file).
     /// </param>
     /// <returns>The resolved absolute-or-relative output file path.</returns>

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/InputResolver.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/InputResolver.cs
@@ -6,26 +6,14 @@ namespace Serilog.Sinks.File.Encrypt.Cli;
 public class InputResolver(IFileSystem fileSystem) : IInputResolver
 {
     /// <inheritdoc />
-    public IReadOnlyList<string> ResolveFiles(string inputPath, bool recursive)
+    public IReadOnlyList<string> ResolveFiles(string inputPath)
     {
         List<string> files = [];
-        string[] foundFiles;
-        SearchOption searchOption;
 
         // Check if it's a direct file path
         if (fileSystem.File.Exists(inputPath))
         {
             files.Add(inputPath);
-            return files;
-        }
-
-        // Check if it's a directory (always uses *.log pattern)
-        if (fileSystem.Directory.Exists(inputPath))
-        {
-            searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-
-            foundFiles = fileSystem.Directory.GetFiles(inputPath, "*.log", searchOption);
-            files.AddRange(FilterDecryptedFiles(foundFiles));
             return files;
         }
 
@@ -48,9 +36,11 @@ public class InputResolver(IFileSystem fileSystem) : IInputResolver
             return files;
         }
 
-        searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-
-        foundFiles = fileSystem.Directory.GetFiles(directory, pattern, searchOption);
+        string[] foundFiles = fileSystem.Directory.GetFiles(
+            directory,
+            pattern,
+            SearchOption.TopDirectoryOnly
+        );
         files.AddRange(FilterDecryptedFiles(foundFiles));
 
         return files;

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/unit/DecryptCommandTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/unit/DecryptCommandTests.cs
@@ -91,9 +91,7 @@ public class DecryptCommandTests : CommandTestBase
         // Arrange
         string emptyDir = Path.Join("empty");
         FileSystem.AddDirectory(emptyDir);
-        _inputResolver
-            .ResolveFiles(Arg.Any<string>(), Arg.Any<bool>())
-            .Returns(Enumerable.Empty<string>());
+        _inputResolver.ResolveFiles(Arg.Any<string>()).Returns(Enumerable.Empty<string>());
 
         DecryptCommand command = GetSut();
         DecryptCommand.Settings settings = new()
@@ -202,7 +200,6 @@ public class DecryptCommandTests : CommandTestBase
         mockFs
             .Directory.GetFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<SearchOption>())
             .Returns([EncryptedFile, lockedFile]);
-
 
         mockFs.File.OpenRead(EncryptedFile).Returns(_ => FileSystem.File.OpenRead(EncryptedFile));
         mockFs
@@ -340,7 +337,7 @@ public class DecryptCommandTests : CommandTestBase
     }
 
     [Fact]
-    public void GivenInputPath_WhenValidDirectory_ThenValidationSucceeds()
+    public void GivenInputPath_WhenValidDirectoryNoPattern_ThenValidationFails()
     {
         // Arrange
         DecryptCommand command = GetSut();
@@ -357,7 +354,12 @@ public class DecryptCommandTests : CommandTestBase
         );
 
         // Assert
-        result.Successful.ShouldBeTrue();
+        result.Successful.ShouldBeFalse();
+        result
+            .Message.ShouldNotBeNull()
+            .ShouldContain(
+                "Input path cannot be a directory. Please specify a file or add a pattern"
+            );
     }
 
     [Fact]
@@ -380,7 +382,7 @@ public class DecryptCommandTests : CommandTestBase
         // Assert
         result.Successful.ShouldBeFalse();
         result.Message.ShouldNotBeNull().ShouldContain("Input path");
-        result.Message.ShouldContain("is not a valid file, directory, or glob pattern.");
+        result.Message.ShouldContain("is not a valid file or directory with pattern.");
     }
 
     [Fact]
@@ -408,7 +410,12 @@ public class DecryptCommandTests : CommandTestBase
 
     private DecryptCommand GetSut(IFileSystem? fileSystem = null)
     {
-        return new DecryptCommand(TestConsole, fileSystem ?? FileSystem, _inputResolver, _outputResolver);
+        return new DecryptCommand(
+            TestConsole,
+            fileSystem ?? FileSystem,
+            _inputResolver,
+            _outputResolver
+        );
     }
 
     /// <summary>
@@ -432,5 +439,5 @@ public class DecryptCommandTests : CommandTestBase
     }
 
     private void ConfigureFileResolver(params string[] encryptedFiles) =>
-        _inputResolver.ResolveFiles(Arg.Any<string>(), Arg.Any<bool>()).Returns(encryptedFiles);
+        _inputResolver.ResolveFiles(Arg.Any<string>()).Returns(encryptedFiles);
 }

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/unit/InputResolverTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/unit/InputResolverTests.cs
@@ -3,6 +3,7 @@ namespace Serilog.Sinks.File.Encrypt.Cli.Tests.unit;
 public class InputResolverTests
 {
     private readonly MockFileSystem _fileSystem = new();
+
     private InputResolver GetSut() => new(_fileSystem);
 
     #region Single File Input
@@ -15,7 +16,7 @@ public class InputResolverTests
         _fileSystem.AddFile(filePath, new MockFileData("content"));
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(filePath, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(filePath);
 
         // Assert
         result.ShouldHaveSingleItem();
@@ -29,7 +30,7 @@ public class InputResolverTests
         string filePath = Path.Join("logs", "app.decrypted.log");
         _fileSystem.AddFile(filePath, new MockFileData("content"));
 
-        IReadOnlyList<string> result = GetSut().ResolveFiles(filePath, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(filePath);
 
         result.ShouldHaveSingleItem();
     }
@@ -43,11 +44,12 @@ public class InputResolverTests
     {
         // Arrange
         string dir = Path.Join("logs");
+        string pattern = Path.Join(dir, "*.log");
         _fileSystem.AddFile(Path.Join(dir, "app1.log"), new MockFileData("content"));
         _fileSystem.AddFile(Path.Join(dir, "app2.log"), new MockFileData("content"));
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(dir, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern);
 
         // Assert
         result.Count.ShouldBe(2);
@@ -58,45 +60,16 @@ public class InputResolverTests
     {
         // Arrange
         string dir = Path.Join("logs");
+        string pattern = Path.Join(dir, "*.log");
         _fileSystem.AddFile(Path.Join(dir, "app.log"), new MockFileData("content"));
         _fileSystem.AddFile(Path.Join(dir, "app.decrypted.log"), new MockFileData("content"));
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(dir, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern);
 
         // Assert
         result.ShouldHaveSingleItem();
         result[0].ShouldContain("app.log");
-    }
-
-    [Fact]
-    public void GivenDirectory_WithRecursiveFalse_DoesNotIncludeSubdirectoryFiles()
-    {
-        // Arrange
-        string dir = Path.Join("logs");
-        _fileSystem.AddFile(Path.Join(dir, "app.log"), new MockFileData("content"));
-        _fileSystem.AddFile(Path.Join(dir, "sub", "nested.log"), new MockFileData("content"));
-
-        // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(dir, recursive: false);
-
-        // Assert
-        result.ShouldHaveSingleItem();
-    }
-
-    [Fact]
-    public void GivenDirectory_WithRecursiveTrue_IncludesSubdirectoryFiles()
-    {
-        // Arrange
-        string dir = Path.Join("logs");
-        _fileSystem.AddFile(Path.Join(dir, "app.log"), new MockFileData("content"));
-        _fileSystem.AddFile(Path.Join(dir, "sub", "nested.log"), new MockFileData("content"));
-
-        // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(dir, recursive: true);
-
-        // Assert
-        result.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -107,7 +80,7 @@ public class InputResolverTests
         _fileSystem.AddDirectory(dir);
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(dir, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(dir);
 
         // Assert
         result.ShouldBeEmpty();
@@ -128,7 +101,7 @@ public class InputResolverTests
         string pattern = Path.Join(dir, "*.log");
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern);
 
         // Assert
         result.Count.ShouldBe(2);
@@ -145,7 +118,7 @@ public class InputResolverTests
         string pattern = Path.Join(dir, "*.log");
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern);
 
         // Assert
         result.ShouldHaveSingleItem();
@@ -158,7 +131,7 @@ public class InputResolverTests
         string pattern = Path.Join("nonexistent", "*.log");
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern);
 
         // Assert
         result.ShouldBeEmpty();
@@ -175,7 +148,7 @@ public class InputResolverTests
         string pattern = "*.log";
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(pattern);
 
         // Assert
         result.Count.ShouldBe(2);
@@ -193,7 +166,7 @@ public class InputResolverTests
         string path = Path.Join("logs", "doesnotexist.log");
 
         // Act
-        IReadOnlyList<string> result = GetSut().ResolveFiles(path, recursive: false);
+        IReadOnlyList<string> result = GetSut().ResolveFiles(path);
 
         // Assert
         result.ShouldBeEmpty();


### PR DESCRIPTION
closes #53

Remove the `-r --recursive` option from the CLI.

Clean up tests and xml docs.  A new issue will be created for updating the README before the release of the next major version.