### PR TITLE
Feature AES decrypt interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [4.0.0] - 2026-04-05
+
+### ⚠️ Breaking Changes
+
+#### `DecryptionOptions.DecryptionKeys` replaced by `DecryptionOptions.KeyProvider`
+
+`DecryptionOptions` no longer holds a `Dictionary<string, string>` of key ID → private key pairs.
+Instead, you must supply an `IKeyProvider` implementation that performs the actual RSA decryption of
+the AES-GCM session key. The built-in `LocalKeyProvider` provides the same dictionary-based
+behaviour as before; implement `IKeyProvider` directly when integrating with an external key
+management system such as Azure Key Vault or AWS KMS.
+
+| v3                                                                                          | v4                                                              |
+|---------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| `DecryptionOptions { DecryptionKeys = new Dictionary<string, string> { { "id", key } } }`  | `DecryptionOptions { KeyProvider = new LocalKeyProvider(map) }` |
+
+```csharp
+// v3
+var options = new DecryptionOptions
+{
+    DecryptionKeys = new Dictionary<string, string>
+    {
+        { "logs-key-2025", oldPrivateKey },
+        { "logs-key-2026", newPrivateKey },
+    }
+};
+
+// v4
+var keyMap = new Dictionary<string, string>
+{
+    { "logs-key-2025", oldPrivateKey },
+    { "logs-key-2026", newPrivateKey },
+};
+using LocalKeyProvider keyProvider = new LocalKeyProvider(keyMap);
+var options = new DecryptionOptions
+{
+    KeyProvider = keyProvider,
+};
+```
+
+> **v4.x can still decrypt v3.x log files.** No need to archive or re-encrypt existing files before upgrading.
+
+---
+
 ## [3.0.0] - 2026-03-22
 
 ### ⚠️ Breaking Changes
@@ -148,4 +192,3 @@ serilog-encrypt decrypt "logs/*.log" -k private_key.xml --id my-app-key-2026
 # if you did not assign a key ID (i.e. used the default).
 serilog-encrypt decrypt app.log -k private_key.xml
 ```
-

--- a/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
+++ b/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
@@ -134,8 +134,10 @@ serilog-encrypt decrypt "logs/2026/*.log" -k ./keys/private_key_2026.xml --id my
 ```
 
 > **Note:** The CLI supports one key per invocation. To decrypt a mixed directory containing files
-> from multiple key rotations, use the programmatic `DecryptionOptions.DecryptionKeys` dictionary
-> in your own application. See the [main package documentation](https://www.nuget.org/packages/Serilog.Sinks.File.Encrypt#readme-body-tab).
+> from multiple key rotations, use the `IKeyProvider` API from the main package to implement custom logic for
+> selecting the correct key and decrypting the AES session. There is a `LocalKeyProvider` implementation included 
+> or write your own that uses Azure Key Vault, AWS KMS, HashiCorp Vault, or any other secure key management system.
+> See the [main package documentation](https://www.nuget.org/packages/Serilog.Sinks.File.Encrypt#readme-body-tab) for details on how to implement and integrate a custom `IKeyProvider`.
 
 ### Error Handling
 

--- a/resources/nuget/Serilog.Sinks.File.Encrypt.md
+++ b/resources/nuget/Serilog.Sinks.File.Encrypt.md
@@ -9,6 +9,11 @@
 A [Serilog.File.Sink](https://github.com/serilog/serilog-sinks-file) hook that encrypts log files using RSA and AES-GCM hybrid encryption. This package provides secure logging by encrypting log data before writing to disk, ensuring sensitive information remains protected.
 
 > [!WARNING]
+> **v4.0.0 DecryptionOptions API Change**
+> The decryption options no longer takes a dictionary of key id → private key pairs. Instead, you must provide
+> a IKeyProvider implementation that can decrypt the AES-GCM session data itself. There is a provided LocalKeyProvider
+> that works similarly to the old API. Use this interface if you use Azure Key Vault, AWS KMS, or any other external key management system where you don't want to load private keys into memory. v4.x can still decrypt v3.x files so there is no concern about rolling log files before upgrading. See the [Migration Guide](#migration-from-v3x-to-v400)
+> 
 > **v3.0.0 is a breaking change from v2.x.**
 > Log files written by v2 cannot be appended to or read by v3. See the [Migration Guide](#migration-from-v2x-to-v300) below and the full [CHANGELOG](https://github.com/byte2pixel/serilog-sinks-file-encrypt/blob/main/CHANGELOG.md) before upgrading.
 
@@ -156,7 +161,7 @@ hooks: new EncryptHooks(oldPublicKey, keyId: "my-app-key-2025")
 hooks: new EncryptHooks(newPublicKey, keyId: "my-app-key-2026")
 ```
 
-**Decryption side** — supply all relevant private keys in `DecryptionOptions.DecryptionKeys`:
+**Decryption side** — Implement a key provider that can decrypt the AES-GCM session data for each key ID. The simplest way is to use the provided `LocalKeyProvider` which takes a dictionary of key ID → private key pairs or implement your own if you use an external key management system like Azure Key Vault or AWS KMS.
 
 ```csharp
 using Serilog.Sinks.File.Encrypt;
@@ -165,13 +170,16 @@ using Serilog.Sinks.File.Encrypt.Models;
 string oldPrivateKey = File.ReadAllText("./keys/private_key_2025.xml");
 string newPrivateKey = File.ReadAllText("./keys/private_key_2026.xml");
 
+var keyMap = new Dictionary<string, string>
+{
+    { "my-app-key-2025", oldPrivateKey },
+    { "my-app-key-2026", newPrivateKey },
+};
+
+using LocalKeyProvider keyProvider = new LocalKeyProvider(keyMap);
 var options = new DecryptionOptions
 {
-    DecryptionKeys = new Dictionary<string, string>
-    {
-        { "my-app-key-2025", oldPrivateKey },
-        { "my-app-key-2026", newPrivateKey },
-    }
+    KeyProvider = keyProvider,
 };
 
 using var input  = File.OpenRead("logs/app.log");
@@ -200,23 +208,25 @@ For large files, use the memory-optimized streaming API:
 using Serilog.Sinks.File.Encrypt;
 using Serilog.Sinks.File.Encrypt.Models;
 
+var keyMap = new Dictionary<string, string>
+{
+    { "my-app-key-2026", File.ReadAllText("private_key.xml") },
+};
+using LocalKeyProvider keyProvider = new LocalKeyProvider(keyMap); // or implement your own IKeyProvider.
+
 // Build decryption options with one or more keys
 var options = new DecryptionOptions
 {
-    DecryptionKeys = new Dictionary<string, string>
-    {
-        { "my-app-key-2026", File.ReadAllText("private_key.xml") },
-    },
-    ErrorHandlingMode = ErrorHandlingMode.Skip  // default
+    KeyProvider = keyProvider,
 };
 
-// File-to-file decryption
+// File-to-file decryption example
 await CryptographicUtils.DecryptLogFileAsync(
     "logs/app.log",
     "logs/decrypted.log",
     options);
 
-// Stream-to-stream decryption
+// Or Stream-to-stream decryption example
 using var input  = File.OpenRead("large-log.encrypted");
 using var output = File.Create("large-log.decrypted");
 await CryptographicUtils.DecryptLogFileAsync(input, output, options);
@@ -232,14 +242,14 @@ using Serilog.Sinks.File.Encrypt.Models;
 // Skip corrupted sections silently (DEFAULT — ideal for JSON/structured logs)
 var skipOptions = new DecryptionOptions
 {
-    DecryptionKeys = ...,
+    KeyProvider = ...,
     ErrorHandlingMode = ErrorHandlingMode.Skip  // This is the default
 };
 
 // Throw exception on first error (strict validation)
 var strictOptions = new DecryptionOptions
 {
-    DecryptionKeys = ...,
+    KeyProvider = ...,
     ErrorHandlingMode = ErrorHandlingMode.ThrowException
 };
 
@@ -253,7 +263,7 @@ await CryptographicUtils.DecryptLogFileAsync(input, output, skipOptions);
 // Continues past corrupted sections; output is clean and safe for structured log parsers.
 var options = new DecryptionOptions
 {
-    DecryptionKeys = new Dictionary<string, string> { { "key-id", privateKey } },
+    KeyProvider = ...,
     ErrorHandlingMode = ErrorHandlingMode.Skip
 };
 
@@ -271,7 +281,7 @@ await CryptographicUtils.DecryptLogFileAsync(input, output, options, auditLogger
 ```csharp
 var options = new DecryptionOptions
 {
-    DecryptionKeys = new Dictionary<string, string> { { "key-id", privateKey } },
+    KeyProvider = ...,
     ErrorHandlingMode = ErrorHandlingMode.ThrowException
 };
 
@@ -341,17 +351,32 @@ Task<DecryptionResult> CryptographicUtils.DecryptLogFileAsync(
     CancellationToken cancellationToken = default)
 ```
 
+### Key Provider Interface
+```csharp
+public interface IKeyProvider
+{
+    // Decrypts the AES-GCM session key using the RSA private key corresponding to the given keyId.
+    Task<byte[]> DecryptAsync(
+        string keyId,
+        ReadOnlyMemory<byte> cipherText,
+        CancellationToken cancellationToken = default
+    );
+    
+    // The header does not contain the key size, this method is needed to determine how many bytes to read to
+    // get the full encrypted session data for decryption.
+    Task<int> GetKeySizeAsync(string keyId, CancellationToken cancellationToken = default);
+}
+```
+
 ### DecryptionOptions
 ```csharp
 public sealed record DecryptionOptions
 {
-    // Dictionary of key ID → RSA private key (XML or PEM).
-    // Use "" as the key when no keyId was assigned during encryption.
-    public required Dictionary<string, string> DecryptionKeys { get; init; }
-
-    // How decryption errors are handled. Default: Skip.
+    // The key provider is responsible for decrypting the AES-GCM session key using the RSA private key.
+    public required IKeyProvider KeyProvider { get; init; }
+    
     public ErrorHandlingMode ErrorHandlingMode { get; init; } = ErrorHandlingMode.Skip;
-}
+};
 ```
 
 ### ErrorHandlingMode
@@ -406,6 +431,10 @@ serilog-encrypt decrypt "logs/*.log" -k private_key.xml --id my-app-key-2026 --a
 ```
 
 For detailed CLI documentation, see the [CLI tool documentation](https://www.nuget.org/packages/Serilog.Sinks.File.Encrypt.Cli).
+
+## Migration from v3.x to v4.0.0
+
+The only breaking change is the DecryptionOptions API change. The new IKeyProvider interface is more flexible and allows you to implement your own key management strategy if you use an external system like Azure Key Vault or AWS KMS. If you were previously using the old dictionary-based API, you can switch to the new LocalKeyProvider which provides similar functionality.
 
 ## Migration from v2.x to v3.0.0
 

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
@@ -183,14 +183,11 @@ public sealed class DecryptCommand(
                 )
                 .CreateLogger();
 
-            var decryptionKeys = new Dictionary<string, string>
-            {
-                { settings.KeyId, rsaPrivateKey },
-            };
+            LocalKeyProvider keyProvider = new(settings.KeyId, rsaPrivateKey);
 
             DecryptionOptions decryptionOptions = new()
             {
-                DecryptionKeys = decryptionKeys,
+                KeyProvider = keyProvider,
                 ErrorHandlingMode = errorMode,
             };
 

--- a/src/Serilog.Sinks.File.Encrypt/CryptographicUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt/CryptographicUtils.cs
@@ -162,25 +162,6 @@ public static class CryptographicUtils
     /// <returns>
     /// A <see cref="DecryptionResult"/> containing counts of decrypted sessions, messages, failures, and resync attempts.
     /// </returns>
-    /// <example>
-    /// <code>
-    /// // Decrypt a log file with error logging
-    /// using var inputStream = File.OpenRead("encrypted.log");
-    /// using var outputStream = File.Create("decrypted.log");
-    /// var options = new DecryptionOptions
-    /// {
-    ///     DecryptionKeys = new Dictionary&lt;string, string&gt; { { "keyId", privateKey } },
-    /// };
-    /// var logger = new LoggerConfiguration().WriteTo.File("decryption_errors.log").CreateLogger();
-    /// var result = await CryptographicUtils.DecryptLogFileAsync(
-    ///     inputStream,
-    ///     outputStream,
-    ///     options,
-    ///     logger,
-    ///     cancellationToken
-    /// );
-    /// </code>
-    /// </example>
     public static async Task<DecryptionResult> DecryptLogFileAsync(
         Stream inputStream,
         Stream outputStream,
@@ -213,31 +194,6 @@ public static class CryptographicUtils
     /// This is a convenience overload that automatically manages file streams. For more control over stream handling,
     /// use the <see cref="DecryptLogFileAsync(Stream, Stream, DecryptionOptions, ILogger?, CancellationToken)"/> overload.
     /// </remarks>
-    /// <example>
-    /// <code>
-    /// // Decrypt a file with default options
-    /// await CryptographicUtils.DecryptLogFileAsync(
-    ///     "logs/encrypted.log",
-    ///     "logs/decrypted.log",
-    ///     privateKey
-    /// );
-    ///
-    /// // Decrypt with error logging
-    /// var options = new StreamingOptions
-    /// {
-    ///     ErrorHandlingMode = ErrorHandlingMode.WriteToErrorLog,
-    ///     ErrorLogPath = "logs/errors.log"
-    /// };
-    ///
-    /// await CryptographicUtils.DecryptLogFileAsync(
-    ///     "logs/encrypted.log",
-    ///     "logs/decrypted.log",
-    ///     privateKey,
-    ///     options,
-    ///     cancellationToken
-    /// );
-    /// </code>
-    /// </example>
     public static async Task<DecryptionResult> DecryptLogFileAsync(
         string encryptedFilePath,
         string outputFilePath,

--- a/src/Serilog.Sinks.File.Encrypt/Interfaces/IHeaderReader.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Interfaces/IHeaderReader.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-
 namespace Serilog.Sinks.File.Encrypt.Interfaces;
 
 /// <summary>
@@ -10,11 +8,15 @@ internal interface IHeaderReader
     /// <summary>
     /// Decrypts the session header information, which includes the RSA-encrypted session key and nonce.
     /// </summary>
-    /// <param name="rsa">The RSA instance containing the private key corresponding to the public key used for encryption.
-    /// This is used to decrypt the AES session key and nonce from the header data.</param>
+    /// <param name="keyProvider">Provides a method for decrypting the AES-GCM session key and nonce.</param>
+    /// <param name="keyId">The key id that was used to encrypt the AES-GCM session key and nonce</param>
     /// <param name="headerData">The encrypted header data read from the log file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A tuple containing the decrypted AES session key, nonce, and timestamp.</returns>
-    /// <exception cref="CryptographicException">Thrown when the decryption fails.</exception>
-    /// <exception cref="InvalidDataException">Thrown when the header data is invalid or does not contain the expected information.</exception>
-    internal (byte[] AesKey, byte[] Nonce) Decrypt(RSA rsa, ReadOnlySpan<byte> headerData);
+    internal Task<(byte[] AesKey, byte[] Nonce)> Decrypt(
+        IKeyProvider keyProvider,
+        string keyId,
+        ReadOnlyMemory<byte> headerData,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Serilog.Sinks.File.Encrypt/Interfaces/IKeyProvider.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Interfaces/IKeyProvider.cs
@@ -1,0 +1,45 @@
+namespace Serilog.Sinks.File.Encrypt.Interfaces;
+
+/// <summary>
+/// The IKeyProvider interface defines the contract for decrypting the random AES-GCM key and nonce.
+/// Implementations of this interface are responsible for providing the logic to retrieve the appropriate
+/// decryption key based on the provided key ID and using it to decrypt the given cipher text.
+/// </summary>
+public interface IKeyProvider
+{
+    /// <summary>
+    /// Decrypts the given cipher text using the decryption key associated with the provided key ID.
+    /// The cipher text is expected to contain the AES-GCM encrypted session key and nonce, which are necessary for
+    /// decrypting the log entries. Implementations of this method should handle the logic for decrypting
+    /// the cipher text and returning the decrypted session key and nonce as a byte array.
+    /// </summary>
+    /// <param name="keyId">The key id that was used to encrypt the AES-GCM session key and nonce</param>
+    /// <param name="cipherText">The AES-GCM encrypted session key and nonce that needs to be decrypted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A byte array containing the decrypted AES-GCM session key and nonce.
+    /// </returns>
+    Task<byte[]> DecryptAsync(
+        string keyId,
+        ReadOnlyMemory<byte> cipherText,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Returns the key size in bits for the RSA key associated with the provided key ID.
+    /// This information is necessary to determine the expected size of the encrypted session key and nonce
+    /// in the header, which is typically equal to the RSA key size divided by 8 (to convert from bits to bytes).
+    /// Implementations of this method should retrieve the appropriate RSA key based on the key ID and return its key size in bits.
+    /// </summary>
+    /// <param name="keyId">The key id that was used to encrypt the AES-GCM session key and nonce</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// An integer representing the key size in bits for the RSA key associated with the provided key ID.
+    /// </returns>
+    /// <remarks>
+    /// Implementations should either build the sizes at construction or cache them after the first retrieval
+    /// to avoid expensive operations on subsequent calls, as the key size is expected to be constant for a given
+    /// key ID.
+    /// </remarks>
+    Task<int> GetKeySizeAsync(string keyId, CancellationToken cancellationToken = default);
+}

--- a/src/Serilog.Sinks.File.Encrypt/Interfaces/ISessionReader.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Interfaces/ISessionReader.cs
@@ -10,10 +10,11 @@ namespace Serilog.Sinks.File.Encrypt.Interfaces;
 internal interface ISessionReader
 {
     /// <summary>
-    /// Reads the session header from the input stream, decrypts it using the appropriate RSA key from the key map
+    /// Reads the session header from the input stream and decrypts it to obtain the AES session key and nonce.
+    /// The session header is expected to be encrypted using RSA, and will be decrypted using the provided <see cref="IKeyProvider"/>
     /// </summary>
     /// <param name="input">The input to decrypt.</param>
-    /// <param name="keyMap">The key map to look up the proper RSA key.</param>
+    /// <param name="keyProvider">The key provider used to decrypt the AES session key and nonce.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="DecryptionContext"/> containing the AES key, nonce for decrypting subsequent messages.</returns>
     /// <exception cref="EndOfStreamException">The end of the stream is reached before the full session info is read.</exception>
@@ -22,7 +23,7 @@ internal interface ISessionReader
     /// <exception cref="InvalidDataException">Thrown when then header is not valid.</exception>
     internal Task<DecryptionContext> ReadSessionAsync(
         Stream input,
-        Dictionary<string, RSA> keyMap,
+        IKeyProvider keyProvider,
         CancellationToken cancellationToken
     );
 }

--- a/src/Serilog.Sinks.File.Encrypt/LocalKeyProvider.cs
+++ b/src/Serilog.Sinks.File.Encrypt/LocalKeyProvider.cs
@@ -1,0 +1,162 @@
+using System.Security.Cryptography;
+using Serilog.Sinks.File.Encrypt.Interfaces;
+
+namespace Serilog.Sinks.File.Encrypt;
+
+/// <summary>
+/// The <see cref="LocalKeyProvider"/> class is an implementation of the <see cref="IKeyProvider"/> interface that
+/// provides RSA decryption capabilities using a local in-memory cache of RSA keys.
+/// This class allows for the decryption of AES-GCM session keys and nonces that are encrypted with RSA,
+/// which are used to encrypt log entries.
+/// </summary>
+public sealed class LocalKeyProvider : IKeyProvider, IDisposable
+{
+    private readonly Dictionary<string, RSA> _rsaKeyCache = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalKeyProvider"/> class with a dictionary of key IDs
+    /// and their corresponding RSA private keys in string format.
+    /// </summary>
+    /// <param name="keyMap">A dictionary mapping key IDs to their corresponding RSA private keys in string format.
+    /// The keys in the dictionary represent the key IDs that will be used to look up the RSA keys for decryption,
+    /// and the values are the RSA private keys in a format that can be parsed by the RSA class (e.g. XML, PEM format).
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown if the provided keyMap is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if the provided keyMap is empty</exception>
+    /// <exception cref="CryptographicException">Thrown if any of the RSA keys in the keyMap are invalid or cannot be parsed.</exception>
+    public LocalKeyProvider(Dictionary<string, string> keyMap)
+    {
+        ArgumentNullException.ThrowIfNull(keyMap);
+        if (keyMap.Count == 0)
+        {
+            throw new ArgumentException("No RSA private key found.");
+        }
+
+        foreach ((string key, string rsa) in keyMap)
+        {
+            try
+            {
+                var rsaKey = RSA.Create();
+                rsaKey.FromString(rsa);
+                _rsaKeyCache.Add(key, rsaKey);
+            }
+            catch (Exception ex)
+                when (ex is CryptographicException or ArgumentNullException or ArgumentException
+                    || ex.GetType().Name.Contains("CryptographicException")
+                )
+            {
+                throw new CryptographicException(
+                    $"Invalid RSA key for key ID '{key}': {ex.Message}",
+                    ex
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalKeyProvider"/> class with a single RSA key.
+    /// </summary>
+    /// <param name="keyId"></param>
+    /// <param name="privateKey"></param>
+    /// <exception cref="CryptographicException"></exception>
+    public LocalKeyProvider(string keyId, string privateKey)
+    {
+        try
+        {
+            var rsa = RSA.Create();
+            rsa.FromString(privateKey);
+            _rsaKeyCache.Add(keyId, rsa);
+        }
+        catch (Exception ex)
+            when (ex is CryptographicException or ArgumentNullException or ArgumentException
+                || ex.GetType().Name.Contains("CryptographicException")
+            )
+        {
+            throw new CryptographicException(
+                $"Invalid RSA key for key ID '{keyId}': {ex.Message}",
+                ex
+            );
+        }
+    }
+
+    /// <summary>
+    /// Decrypts the given cipher text using the decryption key associated with the provided key ID.
+    /// The cipher text is expected to contain the AES-GCM encrypted session key and nonce, which are necessary for
+    /// decrypting the log entries. Implementations of this method should handle the logic for decrypting
+    /// the cipher text and returning the decrypted session key and nonce as a byte array.
+    /// </summary>
+    /// <param name="keyId">The key id that was used to encrypt the AES-GCM session key and nonce</param>
+    /// <param name="cipherText">The AES-GCM encrypted session key and nonce that needs to be decrypted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The decrypted AES-GCM session key and nonce as a byte array.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown if there is no RSA private key found for the provided key ID.</exception>
+    /// <exception cref="CryptographicException">Thrown when RSA decryption of the header fails.</exception>
+    /// <remarks>
+    /// This class implementation of DecryptAsync is not thread safe.
+    /// </remarks>
+    public Task<byte[]> DecryptAsync(
+        string keyId,
+        ReadOnlyMemory<byte> cipherText,
+        CancellationToken cancellationToken = default
+    )
+    {
+        _rsaKeyCache.TryGetValue(keyId, out RSA? rsa);
+        if (rsa == null)
+        {
+            throw new InvalidOperationException($"No RSA private key found for KeyId: '{keyId}'.");
+        }
+        // Decrypt the RSA payload
+        byte[] decryptedPayload;
+        try
+        {
+            decryptedPayload = rsa.Decrypt(cipherText.Span, RSAEncryptionPadding.OaepSHA256);
+        }
+        // this catch is needed because of Interop+Crypto+OpenSslCryptographicException on GitHub Actions Ubuntu runners.
+        // The OpenSSL implementation throws a different exception type that derives from CryptographicException, so we catch both.
+        catch (Exception ex)
+            when (ex is CryptographicException
+                || ex.GetType().Name.Contains("CryptographicException")
+            )
+        {
+            throw new CryptographicException("RSA decryption of header failed.", ex);
+        }
+        return Task.FromResult(decryptedPayload);
+    }
+
+    /// <summary>
+    /// Returns the key size in bits for the RSA key associated with the provided key ID.
+    /// </summary>
+    /// <param name="keyId">The key id that was used to encrypt the AES-GCM session key and nonce</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// An integer representing the key size in bits for the RSA key associated with the provided key ID.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown if there is no RSA private key found for the provided key ID.</exception>
+    /// <remarks>
+    /// This implementation does not need to cache the key sizes since it is all in memory, but any implementations
+    /// that require an external call to retrieve the key size should consider caching the key sizes to avoid unnecessary calls.
+    /// </remarks>
+    public Task<int> GetKeySizeAsync(string keyId, CancellationToken cancellationToken = default)
+    {
+        _rsaKeyCache.TryGetValue(keyId, out RSA? rsa);
+        return rsa == null
+            ? throw new InvalidOperationException("No RSA private key found.")
+            : Task.FromResult(rsa.KeySize);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        DisposeRsaKeys();
+    }
+
+    private void DisposeRsaKeys()
+    {
+        foreach (RSA value in _rsaKeyCache.Values)
+        {
+            value.Dispose();
+        }
+    }
+}

--- a/src/Serilog.Sinks.File.Encrypt/LogReader.cs
+++ b/src/Serilog.Sinks.File.Encrypt/LogReader.cs
@@ -26,7 +26,6 @@ public sealed class LogReader : IDisposable
     private readonly DecryptionOptions _options;
     private DecryptionContext _context = DecryptionContext.Empty;
     private readonly ILogger? _logger;
-    private readonly Dictionary<string, RSA> _rsaKeyCache = new();
     private int _decryptedSessions;
     private int _decryptedMessages;
     private int _failedHeaders;
@@ -41,19 +40,19 @@ public sealed class LogReader : IDisposable
     /// <param name="options">The decryption options</param>
     /// <param name="logger">Optional logger for auditing decryption operations and errors. If not provided, no audit logging will occur.</param>
     /// <exception cref="ArgumentNullException">Thrown if input or options is null</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the decryption keys are null or empty.</exception>
-    /// <exception cref="CryptographicException">Thrown if there is an issue creating an RSA with any of the decryption keys.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if KeyProvider is null</exception>
     /// <remarks>
     /// This class is not thread-safe and should be used for a single decryption operation on a given input stream.
+    /// The caller retains ownership of the input stream and <see cref="DecryptionOptions.KeyProvider"/>
     /// </remarks>
     public LogReader(Stream input, DecryptionOptions options, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(input);
         ArgumentNullException.ThrowIfNull(options);
 
-        if (options.DecryptionKeys is null || options.DecryptionKeys.Count == 0)
+        if (options.KeyProvider is null)
         {
-            throw new InvalidOperationException("At least one decryption key must be provided.");
+            throw new InvalidOperationException("A KeyProvider must be supplied in DecryptionOptions.");
         }
 
         _input = input;
@@ -67,23 +66,6 @@ public sealed class LogReader : IDisposable
             );
         }
 
-        foreach (KeyValuePair<string, string> key in options.DecryptionKeys)
-        {
-            try
-            {
-                var rsa = RSA.Create();
-                rsa.FromString(key.Value);
-                _rsaKeyCache.Add(key.Key, rsa);
-            }
-            catch (Exception ex)
-                when (ex is CryptographicException or ArgumentNullException or ArgumentException)
-            {
-                throw new CryptographicException(
-                    $"Invalid RSA key for key ID '{key.Key}': {ex.Message}",
-                    ex
-                );
-            }
-        }
         _logger?.Information("LogReader initialized, ready to process input stream.");
     }
 
@@ -376,7 +358,7 @@ public sealed class LogReader : IDisposable
             ISessionReader sessionReader = SessionReaderFactory.GetSessionReader(version[0]);
             _context = await sessionReader.ReadSessionAsync(
                 _input,
-                _rsaKeyCache,
+                _options.KeyProvider,
                 cancellationToken
             );
             _decryptedSessions++;
@@ -411,18 +393,7 @@ public sealed class LogReader : IDisposable
         _input.Length - _input.Position >= EncryptionConstants.MagicBytes.Length;
 
     /// <inheritdoc />
-    public void Dispose()
-    {
-        DisposeRsaKeys();
-    }
-
-    private void DisposeRsaKeys()
-    {
-        foreach (RSA value in _rsaKeyCache.Values)
-        {
-            value.Dispose();
-        }
-    }
+    public void Dispose() { }
 
     private int BoyerMooreSearch()
     {

--- a/src/Serilog.Sinks.File.Encrypt/Models/DecryptionOptions.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Models/DecryptionOptions.cs
@@ -1,3 +1,5 @@
+using Serilog.Sinks.File.Encrypt.Interfaces;
+
 namespace Serilog.Sinks.File.Encrypt.Models;
 
 /// <summary>
@@ -6,9 +8,10 @@ namespace Serilog.Sinks.File.Encrypt.Models;
 public sealed record DecryptionOptions
 {
     /// <summary>
-    /// A dictionary of RSA private keys indexed by their corresponding key IDs. This allows for key rotation and supports multiple keys for decryption.
+    /// The <see cref="IKeyProvider"/> implementation responsible for providing the decryption of the AES Session
+    /// key and nonce used to encrypt the log entry(ies). This is a required property and must be set for decryption to work.
     /// </summary>
-    public required Dictionary<string, string> DecryptionKeys { get; init; } = [];
+    public required IKeyProvider KeyProvider { get; init; }
 
     /// <summary>
     /// Defines how decryption errors should be handled.

--- a/src/Serilog.Sinks.File.Encrypt/Readers/v1/HeaderReaderV1.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Readers/v1/HeaderReaderV1.cs
@@ -5,10 +5,24 @@ using Serilog.Sinks.File.Encrypt.Models;
 namespace Serilog.Sinks.File.Encrypt;
 
 /// <inheritdoc />
-public class HeaderReaderV1 : IHeaderReader
+internal class HeaderReaderV1 : IHeaderReader
 {
-    /// <inheritdoc />
-    public (byte[] AesKey, byte[] Nonce) Decrypt(RSA rsa, ReadOnlySpan<byte> headerData)
+    /// <summary>
+    /// Decrypts the session header information, which includes the RSA-encrypted session key and nonce.
+    /// </summary>
+    /// <param name="keyProvider">Provides a method for decrypting the AES-GCM session key and nonce.</param>
+    /// <param name="keyId">The key id that was used to encrypt the AES-GCM session key and nonce</param>
+    /// <param name="headerData">The encrypted header data read from the log file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>>A tuple containing the decrypted AES session key and nonce.</returns>
+    /// <exception cref="CryptographicException">Thrown when RSA decryption of the header fails.</exception>
+    /// <exception cref="InvalidDataException">Thrown when the decrypted payload is too short to contain the expected AES key and nonce.</exception>
+    public async Task<(byte[] AesKey, byte[] Nonce)> Decrypt(
+        IKeyProvider keyProvider,
+        string keyId,
+        ReadOnlyMemory<byte> headerData,
+        CancellationToken cancellationToken = default
+    )
     {
         int offset = 0;
 
@@ -16,7 +30,7 @@ public class HeaderReaderV1 : IHeaderReader
         byte[] decryptedPayload;
         try
         {
-            decryptedPayload = rsa.Decrypt(headerData, RSAEncryptionPadding.OaepSHA256);
+            decryptedPayload = await keyProvider.DecryptAsync(keyId, headerData, cancellationToken);
         }
         // this catch is needed because of Interop+Crypto+OpenSslCryptographicException on GitHub Actions Ubuntu runners.
         // The OpenSSL implementation throws a different exception type that derives from CryptographicException, so we catch both.

--- a/src/Serilog.Sinks.File.Encrypt/Readers/v1/SessionReaderV1.cs
+++ b/src/Serilog.Sinks.File.Encrypt/Readers/v1/SessionReaderV1.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Serilog.Sinks.File.Encrypt.Interfaces;
 using Serilog.Sinks.File.Encrypt.Models;
 
@@ -21,28 +20,29 @@ internal class SessionReaderV1 : ISessionReader
     /// <inheritdoc />
     public async Task<DecryptionContext> ReadSessionAsync(
         Stream input,
-        Dictionary<string, RSA> keyMap,
+        IKeyProvider keyProvider,
         CancellationToken cancellationToken
     )
     {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(keyProvider);
         // Read the header from the input stream
         Memory<byte> keyId = new byte[HeaderMetadataV1.KeyIdLength];
         // lookup the RSA key based on the keyId in the header
         await input.ReadExactlyAsync(keyId, cancellationToken);
         string keyIdStr = System.Text.Encoding.UTF8.GetString(keyId.Span).TrimEnd('\0');
-        if (!keyMap.TryGetValue(keyIdStr, out RSA? rsa))
-        {
-            throw new InvalidOperationException(
-                $"No RSA private key found for KeyId: '{keyIdStr}'."
-            );
-        }
 
-        int headerSize = rsa.KeySize / 8;
+        int headerSize = await keyProvider.GetKeySizeAsync(keyIdStr, cancellationToken) / 8;
         Memory<byte> header = new byte[headerSize];
         await input.ReadExactlyAsync(header, cancellationToken);
 
         // Decrypt the header to get the session key and nonce
-        (byte[] aesKey, byte[] nonce) = _headerReader.Decrypt(rsa, header.Span);
+        (byte[] aesKey, byte[] nonce) = await _headerReader.Decrypt(
+            keyProvider,
+            keyIdStr,
+            header,
+            cancellationToken
+        );
 
         return new DecryptionContext(nonce, aesKey);
     }

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/FileSinkIntegrationTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/FileSinkIntegrationTests.cs
@@ -5,7 +5,7 @@ public sealed class FileSinkIntegrationTests : IDisposable
     private readonly string _testDirectory;
     private readonly string _logFilePath;
     private readonly (string publicKey, string privateKey) _rsaKeyPair;
-    private readonly Dictionary<string, string> _rsaKeyMap = [];
+    private readonly LocalKeyProvider _keyProvider;
     private readonly DecryptionOptions _decryptionOptions;
     private bool _disposed;
 
@@ -22,8 +22,8 @@ public sealed class FileSinkIntegrationTests : IDisposable
 
         // Generate a key pair for testing
         _rsaKeyPair = CryptographicUtils.GenerateRsaKeyPair();
-        _rsaKeyMap.Add("", _rsaKeyPair.privateKey);
-        _decryptionOptions = new DecryptionOptions { DecryptionKeys = _rsaKeyMap };
+        _keyProvider = new LocalKeyProvider("", _rsaKeyPair.privateKey);
+        _decryptionOptions = new DecryptionOptions { KeyProvider = _keyProvider };
     }
 
     private void Dispose(bool disposing)
@@ -32,7 +32,7 @@ public sealed class FileSinkIntegrationTests : IDisposable
         {
             return;
         }
-
+        _keyProvider.Dispose();
         if (disposing)
         {
             // Dispose managed resources here
@@ -190,20 +190,14 @@ public sealed class FileSinkIntegrationTests : IDisposable
         // Generate a different key pair
         (string publicKey, string privateKey) differentKeyPair =
             CryptographicUtils.GenerateRsaKeyPair();
-
+        using LocalKeyProvider differentKeyProvider = new("", differentKeyPair.privateKey);
         // Act & Assert
         await using FileStream inputStream = System.IO.File.OpenRead(_logFilePath);
         using MemoryStream outputStream = new();
         await CryptographicUtils.DecryptLogFileAsync(
             inputStream,
             outputStream,
-            new DecryptionOptions()
-            {
-                DecryptionKeys = new Dictionary<string, string>()
-                {
-                    { "", differentKeyPair.privateKey },
-                },
-            },
+            new DecryptionOptions() { KeyProvider = differentKeyProvider },
             cancellationToken: TestContext.Current.CancellationToken
         );
 
@@ -391,8 +385,13 @@ public sealed class FileSinkIntegrationTests : IDisposable
         // Generate a second key pair
         (string publicKey, string privateKey) secondKeyPair =
             CryptographicUtils.GenerateRsaKeyPair();
-        _decryptionOptions.DecryptionKeys.Add("Key1", _rsaKeyPair.privateKey);
-        _decryptionOptions.DecryptionKeys.Add("Key2", secondKeyPair.privateKey);
+        var keyMap = new Dictionary<string, string>
+        {
+            { "Key1", _rsaKeyPair.privateKey },
+            { "Key2", secondKeyPair.privateKey },
+        };
+        using LocalKeyProvider keyProvider = new(keyMap);
+        DecryptionOptions decryptionOptions = new() { KeyProvider = keyProvider };
 
         // Act - Create two loggers with different encryption keys
         Logger logger1 = new LoggerConfiguration()
@@ -417,7 +416,7 @@ public sealed class FileSinkIntegrationTests : IDisposable
         await CryptographicUtils.DecryptLogFileAsync(
             inputStream1,
             outputStream1,
-            _decryptionOptions,
+            decryptionOptions,
             cancellationToken: TestContext.Current.CancellationToken
         );
 
@@ -426,7 +425,7 @@ public sealed class FileSinkIntegrationTests : IDisposable
         await CryptographicUtils.DecryptLogFileAsync(
             inputStream2,
             outputStream2,
-            _decryptionOptions,
+            decryptionOptions,
             cancellationToken: TestContext.Current.CancellationToken
         );
 
@@ -449,10 +448,7 @@ public sealed class FileSinkIntegrationTests : IDisposable
             crossOutputStream1,
             new DecryptionOptions
             {
-                DecryptionKeys = new Dictionary<string, string>
-                {
-                    { "Key1", secondKeyPair.privateKey }, // add the wrong key with correct key id for cross decryption
-                },
+                KeyProvider = new LocalKeyProvider("Key1", secondKeyPair.privateKey), // add the wrong key with correct key id for cross decryption
             },
             cancellationToken: TestContext.Current.CancellationToken
         );
@@ -464,10 +460,7 @@ public sealed class FileSinkIntegrationTests : IDisposable
             crossOutputStream2,
             new DecryptionOptions
             {
-                DecryptionKeys = new Dictionary<string, string>
-                {
-                    { "Key2", _rsaKeyPair.privateKey }, // add the wrong key with correct key id for cross decryption
-                },
+                KeyProvider = new LocalKeyProvider("Key2", _rsaKeyPair.privateKey), // add the wrong key with correct key id for cross decryption
             },
             cancellationToken: TestContext.Current.CancellationToken
         );

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/TestUtils.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/TestUtils.cs
@@ -22,34 +22,6 @@ internal static class TestUtils
         return GetEncryptionOptions(rsa, keyId, version);
     }
 
-    internal static DecryptionOptions GetDecryptionOptions(
-        Dictionary<string, string> decryptionKeys,
-        ErrorHandlingMode? mode = null
-    )
-    {
-        if (decryptionKeys is null || decryptionKeys.Count == 0)
-        {
-            throw new ArgumentException(
-                "Decryption keys dictionary cannot be empty",
-                nameof(decryptionKeys)
-            );
-        }
-        return new DecryptionOptions
-        {
-            DecryptionKeys = decryptionKeys,
-            ErrorHandlingMode = mode ?? ErrorHandlingMode.Skip,
-        };
-    }
-
-    internal static DecryptionOptions GetDecryptionOptions(
-        string privateKey,
-        string keyId = "",
-        ErrorHandlingMode? mode = null
-    )
-    {
-        return GetDecryptionOptions(new Dictionary<string, string> { { keyId, privateKey } }, mode);
-    }
-
     /// <summary>
     /// Creates a corrupted version of encrypted data by flipping bits at the specified position
     /// </summary>

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/CryptographicUtilsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/CryptographicUtilsTests.cs
@@ -231,14 +231,17 @@ public class CryptographicUtilsTests : EncryptionTestBase
     public async Task EncryptedStream_With4096BitKey_EncryptsAndDecryptsSuccessfully()
     {
         // Arrange
-        (string publicKey, string _) = CryptographicUtils.GenerateRsaKeyPair(keySize: 4096);
+        (string publicKey, string privateKey) = CryptographicUtils.GenerateRsaKeyPair(keySize: 4096);
         const string OriginalText = "Testing 4096-bit RSA key with encrypted stream!";
 
         using var rsa = RSA.Create();
         rsa.FromXmlString(publicKey);
+        EncryptionOptions options = new(rsa, "4096");
+        LocalKeyProvider keyProvider = new("4096", privateKey);
+        DecryptionOptions decryptionOptions = new() { KeyProvider = keyProvider };
 
         // Act - Use helper that manages streams automatically
-        string decrypted = await EncryptAndDecryptAsync(OriginalText);
+        string decrypted = await EncryptAndDecryptAsync(OriginalText, options, decryptionOptions);
 
         // Assert
         decrypted.ShouldBe(OriginalText);
@@ -254,8 +257,8 @@ public class CryptographicUtilsTests : EncryptionTestBase
         using var rsa = RSA.Create();
         rsa.FromString(publicKey);
         EncryptionOptions options = new(rsa, "4096");
-        var map = new Dictionary<string, string> { { options.KeyId, privateKey } };
-        DecryptionOptions decryptionOptions = new() { DecryptionKeys = map };
+        LocalKeyProvider keyProvider = new("4096", privateKey);
+        DecryptionOptions decryptionOptions = new() { KeyProvider = keyProvider };
         const string LogMessage1 = "First log entry with 4096-bit key";
         const string LogMessage2 = "Second log entry with 4096-bit key";
         const string LogMessage3 = "Third log entry with 4096-bit key";

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptedLogStreamAsyncTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptedLogStreamAsyncTests.cs
@@ -54,9 +54,11 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         );
 
         Dictionary<string, string> map = new() { { "4096", privateKey } };
+        using LocalKeyProvider keyProvider = new(map);
+        DecryptionOptions decryptionOptions = new() { KeyProvider = keyProvider };
         string decrypted = await DecryptStreamToStringAsync(
             encryptedStream,
-            TestUtils.GetDecryptionOptions(map)
+            decryptionOptions
         );
 
         // Assert

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptionTestBase.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/EncryptionTestBase.cs
@@ -17,7 +17,8 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
     protected EncryptionTestBase()
     {
         EncryptOptions = CreateEncryptionOptions();
-        DecryptOptions = TestUtils.GetDecryptionOptions(RsaKeyPair.privateKey);
+        LocalKeyProvider keyProvider = new(new Dictionary<string, string> { { "", RsaKeyPair.privateKey } });
+        DecryptOptions = new DecryptionOptions { KeyProvider = keyProvider };
     }
 
     public async ValueTask DisposeAsync()
@@ -244,6 +245,9 @@ public abstract class EncryptionTestBase : IDisposable, IAsyncDisposable
             }
             _streamsToDispose.Clear();
         }
+
+        var keyProvider = DecryptOptions.KeyProvider as LocalKeyProvider;
+        keyProvider?.Dispose();
 
         _disposed = true;
     }

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/LocalKeyProviderTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/LocalKeyProviderTests.cs
@@ -1,0 +1,374 @@
+namespace Serilog.Sinks.File.Encrypt.Tests;
+
+public class LocalKeyProviderTests
+{
+    private static readonly (string PublicKey, string PrivateKey) _xmlKeyPair =
+        CryptographicUtils.GenerateRsaKeyPair(format: KeyFormat.Xml);
+
+    private static readonly (string PublicKey, string PrivateKey) _pemKeyPair =
+        CryptographicUtils.GenerateRsaKeyPair(format: KeyFormat.Pem);
+
+    private static readonly (string PublicKey, string PrivateKey) _keyPair4096 =
+        CryptographicUtils.GenerateRsaKeyPair(keySize: 4096, format: KeyFormat.Xml);
+
+    #region Constructor(Dictionary<string, string>)
+
+    [Fact]
+    public void Constructor_WithNullKeyMap_ThrowsArgumentNullException()
+    {
+        // Arrange
+        Dictionary<string, string> keyMap = null!;
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => new LocalKeyProvider(keyMap));
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyKeyMap_ThrowsArgumentException()
+    {
+        // Arrange
+        var keyMap = new Dictionary<string, string>();
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => new LocalKeyProvider(keyMap));
+    }
+
+    [Fact]
+    public void Constructor_WithValidXmlPrivateKey_CreatesInstanceSuccessfully()
+    {
+        // Arrange
+        var keyMap = new Dictionary<string, string> { { "key1", _xmlKeyPair.PrivateKey } };
+
+        // Act & Assert
+        Should.NotThrow(() =>
+        {
+            using var provider = new LocalKeyProvider(keyMap);
+        });
+    }
+
+    [Fact]
+    public void Constructor_WithValidPemPrivateKey_CreatesInstanceSuccessfully()
+    {
+        // Arrange
+        var keyMap = new Dictionary<string, string> { { "key1", _pemKeyPair.PrivateKey } };
+
+        // Act & Assert
+        Should.NotThrow(() =>
+        {
+            using var provider = new LocalKeyProvider(keyMap);
+        });
+    }
+
+    [Fact]
+    public void Constructor_WithMultipleValidKeys_CreatesInstanceSuccessfully()
+    {
+        // Arrange
+        var keyMap = new Dictionary<string, string>
+        {
+            { "xml-key", _xmlKeyPair.PrivateKey },
+            { "pem-key", _pemKeyPair.PrivateKey },
+        };
+
+        // Act & Assert
+        Should.NotThrow(() =>
+        {
+            using var provider = new LocalKeyProvider(keyMap);
+        });
+    }
+
+    [Fact]
+    public void Constructor_WithInvalidKey_ThrowsCryptographicException()
+    {
+        // Arrange
+        var keyMap = new Dictionary<string, string> { { "key1", "this-is-not-a-valid-rsa-key" } };
+
+        // Act & Assert
+        Should.Throw<CryptographicException>(() => new LocalKeyProvider(keyMap));
+    }
+
+    [Fact]
+    public void Constructor_WithInvalidKey_ExceptionMessageContainsKeyId()
+    {
+        // Arrange
+        const string KeyId = "my-key-id";
+        var keyMap = new Dictionary<string, string> { { KeyId, "invalid-key-data" } };
+
+        // Act & Assert
+        Should
+            .Throw<CryptographicException>(() => new LocalKeyProvider(keyMap))
+            .Message.ShouldContain(KeyId);
+    }
+
+    [Fact]
+    public void Constructor_WithOneInvalidKeyAmongMultiple_ThrowsCryptographicException()
+    {
+        // Arrange
+        const string InvalidKeyId = "bad-key";
+        var keyMap = new Dictionary<string, string>
+        {
+            { "good-key", _xmlKeyPair.PrivateKey },
+            { InvalidKeyId, "not-a-valid-rsa-key" },
+        };
+
+        // Act & Assert
+        Should
+            .Throw<CryptographicException>(() => new LocalKeyProvider(keyMap))
+            .Message.ShouldContain(InvalidKeyId);
+    }
+
+    #endregion
+
+    #region Constructor(string, string)
+
+    [Fact]
+    public void Constructor_SingleKey_WithValidXmlPrivateKey_CreatesInstanceSuccessfully()
+    {
+        // Act & Assert
+        Should.NotThrow(() =>
+        {
+            using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+        });
+    }
+
+    [Fact]
+    public void Constructor_SingleKey_WithValidPemPrivateKey_CreatesInstanceSuccessfully()
+    {
+        // Act & Assert
+        Should.NotThrow(() =>
+        {
+            using var provider = new LocalKeyProvider("key1", _pemKeyPair.PrivateKey);
+        });
+    }
+
+    [Fact]
+    public void Constructor_SingleKey_WithInvalidPrivateKey_ThrowsCryptographicException()
+    {
+        // Act & Assert
+        Should.Throw<CryptographicException>(
+            () => new LocalKeyProvider("key1", "not-a-valid-rsa-key")
+        );
+    }
+
+    [Fact]
+    public void Constructor_SingleKey_WithInvalidKey_ExceptionMessageContainsKeyId()
+    {
+        // Arrange
+        const string KeyId = "my-single-key";
+
+        // Act & Assert
+        Should
+            .Throw<CryptographicException>(() => new LocalKeyProvider(KeyId, "invalid-key"))
+            .Message.ShouldContain(KeyId);
+    }
+
+    #endregion
+
+    #region DecryptAsync
+
+    [Fact]
+    public async Task DecryptAsync_WithValidKeyIdAndEncryptedData_ReturnsOriginalPlaintext()
+    {
+        // Arrange
+        byte[] plaintext = "session-key-and-nonce-data"u8.ToArray();
+        using var publicRsa = RSA.Create();
+        publicRsa.FromString(_xmlKeyPair.PublicKey);
+        byte[] cipherText = publicRsa.Encrypt(plaintext, RSAEncryptionPadding.OaepSHA256);
+
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+
+        // Act
+        byte[] decrypted = await provider.DecryptAsync("key1", cipherText, TestContext.Current.CancellationToken);
+
+        // Assert
+        decrypted.ShouldBe(plaintext);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithUnknownKeyId_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+        byte[] dummyCipherText = new byte[256];
+
+        // Act & Assert
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await provider.DecryptAsync("unknown-key-id", dummyCipherText, TestContext.Current.CancellationToken)
+        );
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithUnknownKeyId_ExceptionMessageContainsKeyId()
+    {
+        // Arrange
+        const string UnknownKeyId = "unknown-key-id";
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+        byte[] dummyCipherText = new byte[256];
+
+        // Act & Assert
+        (await Should.ThrowAsync<InvalidOperationException>(
+            async () => await provider.DecryptAsync(UnknownKeyId, dummyCipherText, TestContext.Current.CancellationToken)
+        )).Message.ShouldContain(UnknownKeyId);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithInvalidCipherText_ThrowsCryptographicException()
+    {
+        // Arrange
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+        byte[] invalidCipherText = RandomNumberGenerator.GetBytes(256);
+
+        // Act & Assert
+        await Should.ThrowAsync<CryptographicException>(
+            async () => await provider.DecryptAsync("key1", invalidCipherText, TestContext.Current.CancellationToken)
+        );
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithCancellationToken_CompletesSuccessfully()
+    {
+        // Arrange
+        byte[] plaintext = "test-data"u8.ToArray();
+        using var publicRsa = RSA.Create();
+        publicRsa.FromString(_xmlKeyPair.PublicKey);
+        byte[] cipherText = publicRsa.Encrypt(plaintext, RSAEncryptionPadding.OaepSHA256);
+
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        byte[] decrypted = await provider.DecryptAsync("key1", cipherText, cts.Token);
+
+        // Assert
+        decrypted.ShouldBe(plaintext);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithMultipleKeys_DecryptsUsingCorrectKey()
+    {
+        // Arrange
+        byte[] plaintext = "multi-key-test"u8.ToArray();
+
+        using var publicRsa2 = RSA.Create();
+        publicRsa2.FromString(_pemKeyPair.PublicKey);
+        byte[] cipherText = publicRsa2.Encrypt(plaintext, RSAEncryptionPadding.OaepSHA256);
+
+        var keyMap = new Dictionary<string, string>
+        {
+            { "key1", _xmlKeyPair.PrivateKey },
+            { "key2", _pemKeyPair.PrivateKey },
+        };
+        using var provider = new LocalKeyProvider(keyMap);
+
+        // Act
+        byte[] decrypted = await provider.DecryptAsync("key2", cipherText, TestContext.Current.CancellationToken);
+
+        // Assert
+        decrypted.ShouldBe(plaintext);
+    }
+
+    #endregion
+
+    #region GetKeySizeAsync
+
+    [Fact]
+    public async Task GetKeySizeAsync_WithDefault2048BitKey_Returns2048()
+    {
+        // Arrange
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+
+        // Act
+        int keySize = await provider.GetKeySizeAsync("key1", TestContext.Current.CancellationToken);
+
+        // Assert
+        keySize.ShouldBe(2048);
+    }
+
+    [Fact]
+    public async Task GetKeySizeAsync_With4096BitKey_Returns4096()
+    {
+        // Arrange
+        using var provider = new LocalKeyProvider("key4096", _keyPair4096.PrivateKey);
+
+        // Act
+        int keySize = await provider.GetKeySizeAsync("key4096", TestContext.Current.CancellationToken);
+
+        // Assert
+        keySize.ShouldBe(4096);
+    }
+
+    [Fact]
+    public async Task GetKeySizeAsync_WithUnknownKeyId_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+
+        // Act & Assert
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await provider.GetKeySizeAsync("unknown-key", TestContext.Current.CancellationToken)
+        );
+    }
+
+    [Fact]
+    public async Task GetKeySizeAsync_WithCancellationToken_CompletesSuccessfully()
+    {
+        // Arrange
+        using var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        int keySize = await provider.GetKeySizeAsync("key1", cts.Token);
+
+        // Assert
+        keySize.ShouldBe(2048);
+    }
+
+    [Fact]
+    public async Task GetKeySizeAsync_WithMultipleKeys_ReturnsCorrectSizeForEachKey()
+    {
+        // Arrange
+        var keyMap = new Dictionary<string, string>
+        {
+            { "key-2048", _xmlKeyPair.PrivateKey },
+            { "key-4096", _keyPair4096.PrivateKey },
+        };
+        using var provider = new LocalKeyProvider(keyMap);
+
+        // Act
+        int size2048 = await provider.GetKeySizeAsync("key-2048", TestContext.Current.CancellationToken);
+        int size4096 = await provider.GetKeySizeAsync("key-4096", TestContext.Current.CancellationToken);
+
+        // Assert
+        size2048.ShouldBe(2048);
+        size4096.ShouldBe(4096);
+    }
+
+    #endregion
+
+    #region IDisposable
+
+    [Fact]
+    public void Dispose_CanBeCalledWithoutException()
+    {
+        // Arrange
+        var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+
+        // Act & Assert
+        Should.NotThrow(provider.Dispose);
+    }
+
+    [Fact]
+    public void Dispose_CalledMultipleTimes_DoesNotThrow()
+    {
+        // Arrange
+        var provider = new LocalKeyProvider("key1", _xmlKeyPair.PrivateKey);
+
+        // Act & Assert
+        Should.NotThrow(() =>
+        {
+            provider.Dispose();
+            provider.Dispose();
+        });
+    }
+
+    #endregion
+}

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/LogReaderTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/LogReaderTests.cs
@@ -1,3 +1,5 @@
+using Serilog.Sinks.File.Encrypt.Interfaces;
+
 namespace Serilog.Sinks.File.Encrypt.Tests;
 
 /// <summary>
@@ -11,7 +13,7 @@ public class LogReaderTests
     public void GivenStreamNull_WhenConstructing_ThenThrows()
     {
         // Arrange
-        DecryptionOptions options = new() { DecryptionKeys = [] };
+        DecryptionOptions options = new() { KeyProvider = Substitute.For<IKeyProvider>() };
 
         // Act & Assert
         Should
@@ -38,11 +40,11 @@ public class LogReaderTests
     }
 
     [Fact]
-    public void GivenNullDecryptionKeys_WhenConstructing_ThenThrows()
+    public void GivenNullKeyProvider_WhenConstructing_ThenThrows()
     {
         // Arrange
         using MemoryStream ms = new();
-        DecryptionOptions options = new() { DecryptionKeys = null! };
+        DecryptionOptions options = new() { KeyProvider = null! };
 
         // Act & Assert
         Should
@@ -50,23 +52,7 @@ public class LogReaderTests
             {
                 using LogReader reader = new(ms, options);
             })
-            .Message.ShouldContain("At least one decryption key must be provided");
-    }
-
-    [Fact]
-    public void GivenEmptyDecryptionKeys_WhenConstructing_ThenThrows()
-    {
-        // Arrange
-        using MemoryStream ms = new();
-        DecryptionOptions options = new() { DecryptionKeys = [] };
-
-        // Act & Assert
-        Should
-            .Throw<InvalidOperationException>(() =>
-            {
-                using LogReader reader = new(ms, options);
-            })
-            .Message.ShouldContain("At least one decryption key must be provided");
+            .Message.ShouldStartWith("A KeyProvider must be");
     }
 
     [Fact]
@@ -74,10 +60,10 @@ public class LogReaderTests
     {
         // Arrange
         using MemoryStream ms = new();
-        DecryptionOptions options = TestUtils.GetDecryptionOptions(
-            "dummy-public",
-            mode: (ErrorHandlingMode)999
-        );
+        (_, string privateKey) = CryptographicUtils.GenerateRsaKeyPair();
+        var keyMap = new Dictionary<string, string>() { { "", privateKey } };
+        using LocalKeyProvider keyProvider = new(keyMap);
+        DecryptionOptions options = new() { KeyProvider = keyProvider, ErrorHandlingMode = (ErrorHandlingMode)999 };
 
         // Act & Assert
         Should

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/Readers/v1/SessionAndHeaderReaderV1Tests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/Readers/v1/SessionAndHeaderReaderV1Tests.cs
@@ -8,18 +8,16 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
     private readonly byte[] _nonce;
     private readonly RSA _encryptionRsa = RSA.Create();
     private const string KeyId = "test-key-id";
-    private readonly Dictionary<string, RSA> _keyMap = [];
-    private readonly DecryptionOptions _decOptions;
+    private readonly LocalKeyProvider _keyProvider;
 
     public SessionAndHeaderReaderV1Tests()
     {
         (string publicKey, string privateKey) = CryptographicUtils.GenerateRsaKeyPair();
         _encryptionRsa.FromString(publicKey);
-        _decOptions = TestUtils.GetDecryptionOptions(privateKey, KeyId);
         _input = new MemoryStream();
         _sut = new SessionReaderV1(new HeaderReaderV1());
+        _keyProvider = new LocalKeyProvider(KeyId, privateKey);
         (_aesKey, _nonce) = TestUtils.CreateSessionData();
-        BuildKeyMap();
     }
 
     [Fact]
@@ -36,7 +34,7 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
         // Act
         DecryptionContext context = await _sut.ReadSessionAsync(
             _input,
-            _keyMap,
+            _keyProvider,
             TestContext.Current.CancellationToken
         );
 
@@ -46,7 +44,7 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
     }
 
     [Fact]
-    public async Task GivenNoMatchingKey_WhenReadSessionAsync_ThenThrows()
+    public async Task GivenNullKeyProvider_WhenReadSessionAsync_ThenThrows()
     {
         // Arrange
         byte[] sessionData = new byte[_aesKey.Length + _nonce.Length];
@@ -57,12 +55,8 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
         _input.Seek(0, SeekOrigin.Begin);
 
         // Act & Assert
-        await Should.ThrowAsync<InvalidOperationException>(async () =>
-            await _sut.ReadSessionAsync(
-                _input,
-                new Dictionary<string, RSA>(), // empty key map to force failure
-                TestContext.Current.CancellationToken
-            )
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await _sut.ReadSessionAsync(_input, null!, TestContext.Current.CancellationToken)
         );
     }
 
@@ -78,7 +72,7 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
 
         // Act & Assert
         var exception = await Should.ThrowAsync<InvalidDataException>(async () =>
-            await _sut.ReadSessionAsync(_input, _keyMap, TestContext.Current.CancellationToken)
+            await _sut.ReadSessionAsync(_input, _keyProvider, TestContext.Current.CancellationToken)
         );
         exception.Message.ShouldContain("Decrypted payload is too short to read AES key");
     }
@@ -100,7 +94,7 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
 
         // Act & Assert
         var exception = await Should.ThrowAsync<InvalidDataException>(async () =>
-            await _sut.ReadSessionAsync(_input, _keyMap, TestContext.Current.CancellationToken)
+            await _sut.ReadSessionAsync(_input, _keyProvider, TestContext.Current.CancellationToken)
         );
         exception.Message.ShouldContain("Decrypted payload is too short to read the nonce");
     }
@@ -123,7 +117,7 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
 
         // Act & Assert
         var exception = await Should.ThrowAsync<CryptographicException>(async () =>
-            await _sut.ReadSessionAsync(_input, _keyMap, TestContext.Current.CancellationToken)
+            await _sut.ReadSessionAsync(_input, _keyProvider, TestContext.Current.CancellationToken)
         );
         exception.Message.ShouldContain("RSA decryption of header failed");
     }
@@ -146,23 +140,10 @@ public sealed class SessionAndHeaderReaderV1Tests : IDisposable
         return header;
     }
 
-    private void BuildKeyMap()
-    {
-        foreach (KeyValuePair<string, string> kvp in _decOptions.DecryptionKeys)
-        {
-            var rsa = RSA.Create();
-            rsa.FromString(kvp.Value);
-            _keyMap[kvp.Key] = rsa;
-        }
-    }
-
     public void Dispose()
     {
         _input.Dispose();
-        foreach (RSA rsa in _keyMap.Values)
-        {
-            rsa.Dispose();
-        }
         _encryptionRsa.Dispose();
+        _keyProvider.Dispose();
     }
 }

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/unit/StreamingDecryptionTests.cs
@@ -34,7 +34,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         const string TestMessage = "Test message with custom options";
         DecryptionOptions customOptions = new()
         {
-            DecryptionKeys = DecryptOptions.DecryptionKeys,
+            KeyProvider = DecryptOptions.KeyProvider,
             ErrorHandlingMode = ErrorHandlingMode.ThrowException,
         };
 
@@ -85,10 +85,10 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
     {
         // Arrange - Do not change message sizes or the marker will not be in the correct offsets for each test.
         string[] messages = ["Good message 1\n", "Good message 2\n"];
-        var keyMap = new Dictionary<string, string> { { "", RsaKeyPair.privateKey } };
+        using LocalKeyProvider keyProvider = new("", RsaKeyPair.privateKey);
         DecryptionOptions decryptionOptions = new()
         {
-            DecryptionKeys = keyMap,
+            KeyProvider = keyProvider,
             // ErrorLogPath = $"decryption_errors_{corruptionOffset}.log",
         };
         // create a session with 2 messages.
@@ -120,7 +120,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         string[] messages = ["Good message 1", "Good message 2"];
         DecryptionOptions skipErrorOptions = new()
         {
-            DecryptionKeys = DecryptOptions.DecryptionKeys,
+            KeyProvider = DecryptOptions.KeyProvider,
             ErrorHandlingMode = ErrorHandlingMode.Skip,
         };
 
@@ -143,10 +143,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
     {
         // Arrange
         string[] messages = ["Good message 1", "Good message 2"];
-        DecryptionOptions errorLogOptions = new()
-        {
-            DecryptionKeys = DecryptOptions.DecryptionKeys,
-        };
+        DecryptionOptions errorLogOptions = new() { KeyProvider = DecryptOptions.KeyProvider };
 
         MemoryStream encryptedStream = await CreateEncryptedStreamAsync(messages);
 
@@ -181,7 +178,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         string[] messages = ["Good message 1", "Good message 2"];
         DecryptionOptions throwExceptionOptions = new()
         {
-            DecryptionKeys = DecryptOptions.DecryptionKeys,
+            KeyProvider = DecryptOptions.KeyProvider,
             ErrorHandlingMode = ErrorHandlingMode.ThrowException,
         };
 
@@ -205,7 +202,7 @@ public sealed class StreamingDecryptionTests : EncryptionTestBase
         string[] messages = ["Message 1", "Message 2", "Message 3"];
         DecryptionOptions throwExceptionOptions = new()
         {
-            DecryptionKeys = DecryptOptions.DecryptionKeys,
+            KeyProvider = DecryptOptions.KeyProvider,
             ErrorHandlingMode = ErrorHandlingMode.ThrowException,
         };
 


### PR DESCRIPTION
This PR alters the decryption logic.  Instead of requiring private keys to be provided the user is free to decide how to decrypt the AES-GCM session data.

All that is required is the key size and then returning the decrypted bytes.  This interface should work for Azure, AWS, Hashicorp and other KMS.

There is a LocalKeyProvider implementation that provides the same functionality as the previous dictionary of kid and private key paris.

This new `IKeyProvider` interface should be much more useful and more secure as the AES session data can be sent to the KMS to be decrypted instead of needing the private key.

Closes #61 