### PR TITLE
Exclude example projects from Build and Package tasks

### DIFF
--- a/build.cs
+++ b/build.cs
@@ -37,20 +37,28 @@ Task("Build")
     .IsDependentOn("Lint")
     .Does(ctx =>
     {
-        ctx.DotNetBuild(
-            Solution,
-            new DotNetBuildSettings
-            {
-                Configuration = configuration,
-                Verbosity = DotNetVerbosity.Minimal,
-                NoLogo = true,
-                NoRestore = true,
-                NoIncremental = ctx.HasArgument("rebuild"),
-                MSBuildSettings = new DotNetMSBuildSettings().TreatAllWarningsAs(
-                    MSBuildTreatAllWarningsAs.Error
-                ),
-            }
-        );
+        var settings = new DotNetBuildSettings
+        {
+            Configuration = configuration,
+            Verbosity = DotNetVerbosity.Minimal,
+            NoLogo = true,
+            NoRestore = true,
+            NoIncremental = ctx.HasArgument("rebuild"),
+            MSBuildSettings = new DotNetMSBuildSettings().TreatAllWarningsAs(
+                MSBuildTreatAllWarningsAs.Error
+            ),
+        };
+
+        // Build only the shipped source and test projects. Example projects under
+        // ./examples are intentionally excluded: they are not shipped, so their
+        // dependencies' vulnerability advisories or warnings should not fail the build.
+        foreach (
+            FilePath project in ctx.GetFiles("./src/**/*.csproj")
+                + ctx.GetFiles("./tests/**/*.csproj")
+        )
+        {
+            ctx.DotNetBuild(project.FullPath, settings);
+        }
     });
 
 Task("Test")
@@ -95,21 +103,24 @@ Task("Package")
     .IsDependentOn("Test")
     .Does(ctx =>
     {
-        ctx.DotNetPack(
-            Solution,
-            new DotNetPackSettings
-            {
-                Configuration = configuration,
-                Verbosity = DotNetVerbosity.Minimal,
-                NoLogo = true,
-                NoRestore = true,
-                NoBuild = true,
-                OutputDirectory = "./.artifacts",
-                MSBuildSettings = new DotNetMSBuildSettings().TreatAllWarningsAs(
-                    MSBuildTreatAllWarningsAs.Error
-                ),
-            }
-        );
+        var settings = new DotNetPackSettings
+        {
+            Configuration = configuration,
+            Verbosity = DotNetVerbosity.Minimal,
+            NoLogo = true,
+            NoRestore = true,
+            NoBuild = true,
+            OutputDirectory = "./.artifacts",
+            MSBuildSettings = new DotNetMSBuildSettings().TreatAllWarningsAs(
+                MSBuildTreatAllWarningsAs.Error
+            ),
+        };
+
+        // Pack only the shipped source projects; example projects are excluded (see Build).
+        foreach (FilePath project in ctx.GetFiles("./src/**/*.csproj"))
+        {
+            ctx.DotNetPack(project.FullPath, settings);
+        }
     });
 
 Task("Publish-NuGet")


### PR DESCRIPTION
## What

Scope the `Build` and `Package` tasks in `build.cs` to the shipped projects only:
- **Build**: `src/**` + `tests/**`
- **Package**: `src/**`

Example projects under `examples/` are no longer compiled/packed by `dotnet make`.

## Why

`Build`/`Package` run with warnings-as-errors. A NuGet audit advisory from a transitive dependency of `examples/Example.WebApi` (`Microsoft.OpenApi`) is elevated to an error, so `dotnet make` fails even though the shipped code is clean. Example projects are not shipped, so their advisories/warnings should not gate the build.

`Restore` and `Lint` remain solution-wide; `Test` already globs `tests/**` only.

## Trade-off

A future compile break in an example project will no longer be caught by `dotnet make`.

## Verification

`dotnet make` completes end-to-end (Clean → Restore → Lint → Build → Test → Package), producing all four NuGet packages.
