### PR TITLE
Fix #78: zero AES session key material after use

### DIFF
--- a/src/Serilog.Sinks.File.Decrypt/LogReader.cs
+++ b/src/Serilog.Sinks.File.Decrypt/LogReader.cs
@@ -187,7 +187,7 @@ public sealed class LogReader : IDisposable
                 _logger?.Information(
                     "Session header marker likely encountered while reading messages."
                 );
-                _context = DecryptionContext.Empty;
+                ReplaceContext(DecryptionContext.Empty);
                 _state = ReaderState.ReadingHeader;
                 _nextSyncPosition = _input.Position - sizeof(int); // Rewind to start of potential header
                 return;
@@ -236,7 +236,7 @@ public sealed class LogReader : IDisposable
             _logger?.Error(ex, "Message processing error at position: {Position}", _input.Position);
             _resyncAttempts++;
             _failedMessages++;
-            _context = DecryptionContext.Empty;
+            ReplaceContext(DecryptionContext.Empty);
             _state = ReaderState.ReadingHeader;
         }
     }
@@ -376,10 +376,12 @@ public sealed class LogReader : IDisposable
                 throw new NotSupportedException($"Unsupported encryption version: {version[0]}");
             }
             ISessionReader sessionReader = new SessionReader();
-            _context = await sessionReader.ReadSessionAsync(
-                _input,
-                _options.KeyProvider,
-                cancellationToken
+            ReplaceContext(
+                await sessionReader.ReadSessionAsync(
+                    _input,
+                    _options.KeyProvider,
+                    cancellationToken
+                )
             );
             _decryptedSessions++;
             _nextSyncPosition = _input.Position;
@@ -412,8 +414,22 @@ public sealed class LogReader : IDisposable
     private bool IsRoomForMagicBytes() =>
         _input.Length - _input.Position >= CryptographicUtils.MagicBytes.Length;
 
+    /// <summary>
+    /// Replaces the active decryption context, zeroing the previous session's key material first
+    /// so it does not linger in managed memory.
+    /// </summary>
+    private void ReplaceContext(DecryptionContext next)
+    {
+        _context.Clear();
+        _context = next;
+    }
+
     /// <inheritdoc />
-    public void Dispose() { }
+    public void Dispose()
+    {
+        // Wipe any remaining session key material.
+        _context.Clear();
+    }
 
     private int BoyerMooreSearch()
     {

--- a/src/Serilog.Sinks.File.Decrypt/Models/DecryptionContext.cs
+++ b/src/Serilog.Sinks.File.Decrypt/Models/DecryptionContext.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace Serilog.Sinks.File.Decrypt.Models;
 
 /// <summary>
@@ -26,4 +28,14 @@ public class DecryptionContext(byte[] nonce, byte[] sessionKey)
     /// Returns true if both the Nonce and SessionKey are present, indicating that decryption can proceed.
     /// </summary>
     public bool HasKeys => Nonce.Length > 0 && SessionKey.Length > 0;
+
+    /// <summary>
+    /// Zeroes the session key and nonce so this sensitive key material does not linger in managed memory
+    /// after the session has been processed.
+    /// </summary>
+    public void Clear()
+    {
+        CryptographicOperations.ZeroMemory(SessionKey);
+        CryptographicOperations.ZeroMemory(Nonce);
+    }
 }

--- a/src/Serilog.Sinks.File.Decrypt/Models/DecryptionContext.cs
+++ b/src/Serilog.Sinks.File.Decrypt/Models/DecryptionContext.cs
@@ -25,7 +25,9 @@ public class DecryptionContext(byte[] nonce, byte[] sessionKey)
     public static DecryptionContext Empty => new([], []);
 
     /// <summary>
-    /// Returns true if both the Nonce and SessionKey are present, indicating that decryption can proceed.
+    /// Returns true if the Nonce and SessionKey buffers are present (non-empty).
+    /// Note this only reflects buffer presence, not cryptographic validity: after <see cref="Clear"/>
+    /// the buffers remain non-empty (so this stays true) even though the key material has been wiped.
     /// </summary>
     public bool HasKeys => Nonce.Length > 0 && SessionKey.Length > 0;
 

--- a/src/Serilog.Sinks.File.Decrypt/Readers/HeaderReader.cs
+++ b/src/Serilog.Sinks.File.Decrypt/Readers/HeaderReader.cs
@@ -41,22 +41,31 @@ internal class HeaderReader : IHeaderReader
         {
             throw new CryptographicException("RSA decryption of header failed.", ex);
         }
-        // Read AES key
-        if (decryptedPayload.Length < HeaderMetadata.AesKeyLength)
+        try
         {
-            throw new InvalidDataException("Decrypted payload is too short to read AES key");
+            // Read AES key
+            if (decryptedPayload.Length < HeaderMetadata.AesKeyLength)
+            {
+                throw new InvalidDataException("Decrypted payload is too short to read AES key");
+            }
+
+            byte[] aesKey = decryptedPayload[offset..(HeaderMetadata.AesKeyLength)];
+            offset += HeaderMetadata.AesKeyLength;
+
+            if (decryptedPayload.Length < offset + HeaderMetadata.NonceLength)
+            {
+                throw new InvalidDataException("Decrypted payload is too short to read the nonce.");
+            }
+
+            byte[] nonce = decryptedPayload[offset..(offset + HeaderMetadata.NonceLength)];
+
+            return (aesKey, nonce);
         }
-
-        byte[] aesKey = decryptedPayload[offset..(HeaderMetadata.AesKeyLength)];
-        offset += HeaderMetadata.AesKeyLength;
-
-        if (decryptedPayload.Length < offset + HeaderMetadata.NonceLength)
+        finally
         {
-            throw new InvalidDataException("Decrypted payload is too short to read the nonce.");
+            // The RSA-decrypted payload contains the AES key and nonce; wipe it once the
+            // key and nonce have been copied out (or on any failure) so it does not linger.
+            CryptographicOperations.ZeroMemory(decryptedPayload);
         }
-
-        byte[] nonce = decryptedPayload[offset..(offset + HeaderMetadata.NonceLength)];
-
-        return (aesKey, nonce);
     }
 }

--- a/src/Serilog.Sinks.File.Decrypt/Readers/HeaderReader.cs
+++ b/src/Serilog.Sinks.File.Decrypt/Readers/HeaderReader.cs
@@ -49,7 +49,7 @@ internal class HeaderReader : IHeaderReader
                 throw new InvalidDataException("Decrypted payload is too short to read AES key");
             }
 
-            byte[] aesKey = decryptedPayload[offset..(HeaderMetadata.AesKeyLength)];
+            byte[] aesKey = decryptedPayload[offset..(offset + HeaderMetadata.AesKeyLength)];
             offset += HeaderMetadata.AesKeyLength;
 
             if (decryptedPayload.Length < offset + HeaderMetadata.NonceLength)

--- a/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
@@ -192,13 +192,19 @@ public sealed class LogWriter : Stream
     {
         if (disposing)
         {
-            Flush();
-            _inner.Dispose();
-            _aesGcm?.Dispose();
-
-            // Wipe the session key and nonce so they do not linger in managed memory.
-            CryptographicOperations.ZeroMemory(_aesKey);
-            CryptographicOperations.ZeroMemory(_nonce);
+            try
+            {
+                Flush();
+                _inner.Dispose();
+                _aesGcm?.Dispose();
+            }
+            finally
+            {
+                // Wipe the session key and nonce so they do not linger in managed memory,
+                // even if flushing or disposing the inner stream throws.
+                CryptographicOperations.ZeroMemory(_aesKey);
+                CryptographicOperations.ZeroMemory(_nonce);
+            }
         }
         base.Dispose(disposing);
     }

--- a/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
@@ -195,6 +195,10 @@ public sealed class LogWriter : Stream
             Flush();
             _inner.Dispose();
             _aesGcm?.Dispose();
+
+            // Wipe the session key and nonce so they do not linger in managed memory.
+            CryptographicOperations.ZeroMemory(_aesKey);
+            CryptographicOperations.ZeroMemory(_nonce);
         }
         base.Dispose(disposing);
     }

--- a/tests/Serilog.Sinks.File.Decrypt.Tests/DecryptionContextTests.cs
+++ b/tests/Serilog.Sinks.File.Decrypt.Tests/DecryptionContextTests.cs
@@ -29,4 +29,30 @@ public class DecryptionContextTests
         context.Nonce.ShouldBe([]);
         context.SessionKey.ShouldBe([]);
     }
+
+    [Fact]
+    public void Clear_ZeroesSessionKeyAndNonce()
+    {
+        // Arrange
+        byte[] nonce = RandomNumberGenerator.GetBytes(EncryptionConstants.NonceLength);
+        byte[] sessionKey = RandomNumberGenerator.GetBytes(EncryptionConstants.SessionKeyLength);
+        var context = new DecryptionContext(nonce, sessionKey);
+
+        // Act
+        context.Clear();
+
+        // Assert - key material is wiped in place
+        context.SessionKey.ShouldAllBe(b => b == 0);
+        context.Nonce.ShouldAllBe(b => b == 0);
+    }
+
+    [Fact]
+    public void Clear_OnEmptyContext_DoesNotThrow()
+    {
+        // Arrange
+        DecryptionContext context = DecryptionContext.Empty;
+
+        // Act & Assert
+        Should.NotThrow(context.Clear);
+    }
 }

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptedLogStreamAsyncTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptedLogStreamAsyncTests.cs
@@ -196,7 +196,7 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
     }
 
     [Fact]
-    public void Dispose_ZeroesSessionKeyAndNonce()
+    public async Task Dispose_ZeroesSessionKeyAndNonce()
     {
         // Arrange
         (string publicKey, _) = CryptographicUtils.GenerateRsaKeyPair();
@@ -204,7 +204,7 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         using RSA rsa = RSA.Create();
         rsa.FromXmlString(publicKey);
         EncryptionOptions options = new(rsa);
-        LogWriter logWriter = new(fs, options);
+        await using LogWriter logWriter = new(fs, options);
 
         byte[] data = "sensitive log data"u8.ToArray();
         logWriter.Write(data, 0, data.Length);
@@ -216,7 +216,7 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         aesKey.ShouldContain(b => b != 0); // the session key was generated
 
         // Act
-        logWriter.Dispose();
+        await logWriter.DisposeAsync();
 
         // Assert - the buffers are wiped in place
         aesKey.ShouldAllBe(b => b == 0);

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptedLogStreamAsyncTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptedLogStreamAsyncTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 namespace Serilog.Sinks.File.Encrypt.Tests;
 
@@ -192,5 +193,42 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         await Should.ThrowAsync<OperationCanceledException>(async () =>
             await logWriter.WriteAsync(data, cts.Token)
         );
+    }
+
+    [Fact]
+    public void Dispose_ZeroesSessionKeyAndNonce()
+    {
+        // Arrange
+        (string publicKey, _) = CryptographicUtils.GenerateRsaKeyPair();
+        using MemoryStream fs = new();
+        using RSA rsa = RSA.Create();
+        rsa.FromXmlString(publicKey);
+        EncryptionOptions options = new(rsa);
+        LogWriter logWriter = new(fs, options);
+
+        byte[] data = "sensitive log data"u8.ToArray();
+        logWriter.Write(data, 0, data.Length);
+        logWriter.Flush();
+
+        // Grab references to the reusable key/nonce buffers before disposing.
+        byte[] aesKey = GetPrivateArray(logWriter, "_aesKey");
+        byte[] nonce = GetPrivateArray(logWriter, "_nonce");
+        aesKey.ShouldContain(b => b != 0); // the session key was generated
+
+        // Act
+        logWriter.Dispose();
+
+        // Assert - the buffers are wiped in place
+        aesKey.ShouldAllBe(b => b == 0);
+        nonce.ShouldAllBe(b => b == 0);
+    }
+
+    private static byte[] GetPrivateArray(LogWriter writer, string fieldName)
+    {
+        FieldInfo field = typeof(LogWriter).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        return (byte[])field.GetValue(writer)!;
     }
 }


### PR DESCRIPTION
Closes #78.

## Problem

Session key material was left in the managed heap for the GC on both the encrypt and decrypt sides, even though `HeaderWriter` already wipes its RSA scratch buffer. 256-bit AES session keys, nonces, and the RSA-decrypted key payload lingered in memory (and could be relocated by the GC).

## Fix (defense-in-depth, no public behavior change)

- **`LogWriter.Dispose`** now zeroes the reusable `_aesKey` and `_nonce` buffers.
- **`DecryptionContext`** gains a `Clear()` method that zeroes `SessionKey` and `Nonce`.
- **`LogReader`** zeroes each session'\''s context via a new `ReplaceContext` helper whenever the context is replaced (resync, new session) and on `Dispose` (previously an empty no-op).
- **`HeaderReader`** zeroes the RSA-decrypted payload (which holds the AES key + nonce) in a `finally`, once the key and nonce have been copied out (or on failure).

All wiping uses `CryptographicOperations.ZeroMemory`.

## Tests

- `DecryptionContextTests`: `Clear` zeroes key/nonce; `Clear` on an empty context is a no-op.
- `EncryptedLogStreamAsyncTests`: `LogWriter.Dispose` wipes its `_aesKey`/`_nonce` buffers (verified via reflection).
- Existing multi-session / resync decryption tests continue to pass, exercising the new `ReplaceContext` paths.

`dotnet make` is green end-to-end (Lint, warnings-as-errors Build, Test, Package).

## Note

Touches `LogReader.cs` in regions near #87 (#77); whichever merges second will need a trivial rebase (no logical overlap).