### PR TITLE
Fix #80: validate EncryptHooks arguments at construction

### DIFF
--- a/src/Serilog.Sinks.File.Encrypt/EncryptHooks.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptHooks.cs
@@ -51,7 +51,8 @@ public class EncryptHooks : FileLifecycleHooks
     /// <param name="publicKey">The RSA public key in XML or PEM format. Use <see cref="CryptographicUtils.GenerateRsaKeyPair"/> to generate keys.</param>
     /// <param name="keyId">Optional key ID to include in the header for key rotation. Default is an empty string. Max 32 bytes.</param>
     /// <param name="version">Retained for backward compatibility. This value is ignored; the library always uses version 1 of the header format.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="publicKey"/> is null or whitespace.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="publicKey"/> or <paramref name="keyId"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="publicKey"/> is empty or whitespace, or when <paramref name="keyId"/> exceeds 32 bytes when UTF-8 encoded.</exception>
     /// <exception cref="FormatException">Thrown when <paramref name="publicKey"/> is in an invalid format.</exception>
     /// <exception cref="CryptographicException">Thrown when the key format is invalid, cannot be parsed. or is too small.</exception>
     /// <remarks>
@@ -70,7 +71,20 @@ public class EncryptHooks : FileLifecycleHooks
     /// </example>
     public EncryptHooks(string publicKey, string keyId = "", int version = 1)
     {
-        ArgumentNullException.ThrowIfNull(publicKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicKey);
+        ArgumentNullException.ThrowIfNull(keyId);
+
+        // Validate the keyId length up front so misconfiguration fails at logger construction
+        // rather than on the first log write, deep inside Serilog's write path.
+        int keyIdByteLength = Encoding.UTF8.GetByteCount(keyId);
+        if (keyIdByteLength > HeaderMetadata.KeyIdLength)
+        {
+            throw new ArgumentException(
+                $"KeyId is too long for the header format. Maximum length is {HeaderMetadata.KeyIdLength} bytes, but was {keyIdByteLength} bytes.",
+                nameof(keyId)
+            );
+        }
+
         RSA rsa = _rsaCache.GetOrAdd(publicKey, CreateRsaFromString);
         _encryptionOptions = new EncryptionOptions(rsa, keyId, version);
     }

--- a/src/Serilog.Sinks.File.Encrypt/EncryptHooks.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptHooks.cs
@@ -54,7 +54,7 @@ public class EncryptHooks : FileLifecycleHooks
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="publicKey"/> or <paramref name="keyId"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="publicKey"/> is empty or whitespace, or when <paramref name="keyId"/> exceeds 32 bytes when UTF-8 encoded.</exception>
     /// <exception cref="FormatException">Thrown when <paramref name="publicKey"/> is in an invalid format.</exception>
-    /// <exception cref="CryptographicException">Thrown when the key format is invalid, cannot be parsed. or is too small.</exception>
+    /// <exception cref="CryptographicException">Thrown when the key format is invalid, cannot be parsed, or is too small.</exception>
     /// <remarks>
     /// The public key is loaded and validated during construction.
     /// </remarks>

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptHooksTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptHooksTests.cs
@@ -39,7 +39,8 @@ public class EncryptHooksTests
     )
     {
         // Act & Assert
-        Should.Throw<ArgumentException>(() => new EncryptHooks(publicKey));
+        ArgumentException ex = Should.Throw<ArgumentException>(() => new EncryptHooks(publicKey));
+        ex.GetType().ShouldBe(typeof(ArgumentException));
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptHooksTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptHooksTests.cs
@@ -31,6 +31,59 @@ public class EncryptHooksTests
         Should.Throw<CryptographicException>(() => new EncryptHooks(publicKey));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GivenEmptyOrWhitespacePublicKey_WhenCreatingEncryptHooks_ThenArgumentExceptionIsThrown(
+        string publicKey
+    )
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => new EncryptHooks(publicKey));
+    }
+
+    [Fact]
+    public void GivenNullPublicKey_WhenCreatingEncryptHooks_ThenArgumentNullExceptionIsThrown()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => new EncryptHooks(null!));
+    }
+
+    [Fact]
+    public void GivenNullKeyId_WhenCreatingEncryptHooks_ThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        (string publicKey, string _) = CryptographicUtils.GenerateRsaKeyPair();
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => new EncryptHooks(publicKey, null!));
+    }
+
+    [Fact]
+    public void GivenKeyIdLongerThan32Bytes_WhenCreatingEncryptHooks_ThenArgumentExceptionIsThrown()
+    {
+        // Arrange
+        (string publicKey, string _) = CryptographicUtils.GenerateRsaKeyPair();
+        string tooLongKeyId = new('a', 33);
+
+        // Act & Assert - fails at construction, not on the first log write
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            new EncryptHooks(publicKey, tooLongKeyId)
+        );
+        ex.ParamName.ShouldBe("keyId");
+    }
+
+    [Fact]
+    public void GivenKeyIdExactly32Bytes_WhenCreatingEncryptHooks_ThenNoExceptionIsThrown()
+    {
+        // Arrange
+        (string publicKey, string _) = CryptographicUtils.GenerateRsaKeyPair();
+        string maxKeyId = new('a', 32);
+
+        // Act & Assert
+        Should.NotThrow(() => new EncryptHooks(publicKey, maxKeyId));
+    }
+
     [Fact]
     public void OnFileOpened_ReturnsEncryptedStream()
     {


### PR DESCRIPTION
Closes #80.

## Problem

`EncryptHooks` accepted invalid configuration and only surfaced it later, on the first log write:
- A `keyId` longer than 32 UTF-8 bytes was accepted by the constructor and only threw `InvalidOperationException` inside `SessionWriter.WriteHeader` on the first log line.
- A whitespace-only `publicKey` passed `ArgumentNullException.ThrowIfNull` and then produced a less-clear `CryptographicException`, despite the docs claiming the constructor throws on null/whitespace.

## Fix (non-breaking, fail-fast)

Validate in the `EncryptHooks` constructor:
- `ArgumentException.ThrowIfNullOrWhiteSpace(publicKey)`
- `ArgumentNullException.ThrowIfNull(keyId)`
- throw `ArgumentException` (paramName `keyId`) when the UTF-8 byte length of `keyId` exceeds `HeaderMetadata.KeyIdLength` (32)

The existing `SessionWriter` length check is retained as a last line of defense for callers that construct `EncryptionOptions`/`LogWriter` directly. Constructor `<exception>` docs updated to match.

## Tests

Added to `EncryptHooksTests`: empty/whitespace `publicKey` → `ArgumentException`; null `publicKey`/`keyId` → `ArgumentNullException`; `keyId` > 32 bytes → `ArgumentException` at construction (asserts `ParamName`); `keyId` == 32 bytes → no throw.

`dotnet make` is green end-to-end (Lint, warnings-as-errors Build, Test, Package).