### PR TITLE
Fix #79: enforce documented 2048-bit minimum in GenerateRsaKeyPair

### DIFF
--- a/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
@@ -104,7 +104,7 @@ public static class CryptographicUtils
     /// <param name="format">The format in which to export the keys. Default is XML.</param>
     /// <returns>A tuple containing the public and private keys in XML or PEM format. The public key should be distributed to log producers, while the private key must be kept secure.</returns>
     /// <exception cref="NotSupportedException">Thrown when the key format is not supported.</exception>
-    /// <exception cref="CryptographicException">Thrown when key generation fails or the key size is invalid.</exception>
+    /// <exception cref="CryptographicException">Thrown when key generation fails, or when <paramref name="keySize"/> is less than the 2048-bit minimum.</exception>
     /// <remarks>
     /// <para>
     /// <b>Key Size Recommendations:</b>
@@ -134,6 +134,15 @@ public static class CryptographicUtils
         KeyFormat format = KeyFormat.Xml
     )
     {
+        // Enforce the documented minimum up front. RSA.Create would happily create a weak
+        // (e.g. 1024-bit) key otherwise, contradicting the contract and MinimumRsaKeySize.
+        if (keySize < EncryptionConstants.MinimumRsaKeySize)
+        {
+            throw new CryptographicException(
+                $"RSA key size must be at least {EncryptionConstants.MinimumRsaKeySize} bits, but was {keySize}."
+            );
+        }
+
         using RSA rsa = RSA.Create(keySize);
 
         (string publicKey, string privateKey) = format switch

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
@@ -188,6 +188,39 @@ public class CryptographicUtilsTests : EncryptionTestBase
         decryptedData.ShouldBe(data);
     }
 
+    [Theory]
+    [InlineData(1024)]
+    [InlineData(2047)]
+    [InlineData(512)]
+    public void GenerateRsaKeyPair_WithKeySizeBelowMinimum_ThrowsCryptographicException(int keySize)
+    {
+        // Act & Assert
+        Should
+            .Throw<CryptographicException>(() =>
+                CryptographicUtils.GenerateRsaKeyPair(keySize: keySize)
+            )
+            .Message.ShouldContain("at least");
+    }
+
+    [Fact]
+    public void GenerateRsaKeyPair_WithMinimumKeySize_ReturnsValidKeys()
+    {
+        // Arrange & Act
+        (string publicKey, string privateKey) = CryptographicUtils.GenerateRsaKeyPair(
+            keySize: EncryptionConstants.MinimumRsaKeySize
+        );
+
+        using var privateKeyRsa = RSA.Create();
+        privateKeyRsa.FromString(privateKey);
+
+        using var publicKeyRsa = RSA.Create();
+        publicKeyRsa.FromString(publicKey);
+
+        // Assert
+        privateKeyRsa.KeySize.ShouldBe(EncryptionConstants.MinimumRsaKeySize);
+        publicKeyRsa.KeySize.ShouldBe(EncryptionConstants.MinimumRsaKeySize);
+    }
+
     [Fact]
     public void GenerateRsaKeyPair_WithInvalidFormat_ThrowsArgumentException()
     {


### PR DESCRIPTION
Closes #79.

## Problem

`GenerateRsaKeyPair` documents *"Must be at least 2048"* and `EncryptionConstants.MinimumRsaKeySize = 2048` exists, but the method called `RSA.Create(keySize)` with no validation — so a weak key (e.g. 1024-bit) could be generated silently, contradicting the contract. It was only rejected later, at encryption time, by `EncryptHooks`.

## Fix (non-breaking; aligns code with the documented contract)

Throw when `keySize < EncryptionConstants.MinimumRsaKeySize`.

**Why `CryptographicException` (not `ArgumentOutOfRangeException`):**
- The existing `<exception>` doc already declares `CryptographicException` for an invalid key size.
- The `GenerateCommand` CLI already catches `CryptographicException` and prints a clean error; throwing `ArgumentOutOfRangeException` would instead crash the CLI on `--key-size 1024` (it doesn'\''t catch that type).

## Tests

Added to `CryptographicUtilsTests`: key sizes below the minimum (`1024`, `2047`, `512`) → `CryptographicException`; the exact minimum (`2048`) still produces valid, usable keys.

`dotnet make` is green end-to-end (Lint, warnings-as-errors Build, Test, Package).