### PR TITLE
Fix #81: documentation and cosmetic cleanups

### DIFF
--- a/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
@@ -25,6 +25,10 @@ public static class CryptographicUtils
     /// 0xFF, 0xDA, 0x7E: Random bytes for additional uniqueness
     /// 0x00: Reserved byte (must be 0)
     /// </summary>
+    /// <remarks>
+    /// Treat this as read-only. Only the array reference is <c>readonly</c>; its elements are not, so mutating
+    /// them would corrupt the file-format marker process-wide. Do not modify the contents.
+    /// </remarks>
     public static readonly byte[] MagicBytes = [0xFF, 0x42, 0x32, 0x50, 0xFF, 0xDA, 0x7E, 0x00];
 
     /// <summary>
@@ -78,7 +82,8 @@ public static class CryptographicUtils
 
     /// <summary>
     /// AES-GCM encryption requires a unique nonce for each encryption operation.
-    /// This method increments the nonce value stored in the last 12 bytes of the data array.
+    /// This method increments the 64-bit little-endian counter stored in the last 8 bytes of the nonce.
+    /// The encryptor and decryptor advance this counter in lockstep, so both must use this same helper.
     /// </summary>
     /// <param name="nonce">Nonce of any length >= 12</param>
     /// <exception cref="ArgumentNullException">
@@ -92,7 +97,7 @@ public static class CryptographicUtils
         ArgumentNullException.ThrowIfNull(nonce);
         ArgumentOutOfRangeException.ThrowIfLessThan(nonce.Length, 12);
 
-        long value = nonce.GetNonce() + (1 % long.MaxValue);
+        long value = nonce.GetNonce() + 1;
         byte[] nonceBytes = BitConverter.GetBytes(value);
         nonceBytes.CopyTo(nonce, nonce.Length - sizeof(long));
     }

--- a/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 using Serilog.Sinks.File.Encrypt.Models;
 
@@ -71,13 +72,13 @@ public static class CryptographicUtils
 
     /// <summary>
     /// AES-GCM encryption requires a unique nonce for each encryption operation.
-    /// This method retrieves the current nonce value stored in the last 8 bytes of the data array.
+    /// This method retrieves the 64-bit little-endian counter stored in the last 8 bytes of the nonce.
     /// </summary>
     /// <param name="nonce">Nonce of any length >= 12</param>
     /// <returns>The current nonce counter value.</returns>
     private static long GetNonce(this byte[] nonce)
     {
-        return BitConverter.ToInt64(nonce, nonce.Length - sizeof(long));
+        return BinaryPrimitives.ReadInt64LittleEndian(nonce.AsSpan(nonce.Length - sizeof(long)));
     }
 
     /// <summary>
@@ -98,8 +99,7 @@ public static class CryptographicUtils
         ArgumentOutOfRangeException.ThrowIfLessThan(nonce.Length, 12);
 
         long value = nonce.GetNonce() + 1;
-        byte[] nonceBytes = BitConverter.GetBytes(value);
-        nonceBytes.CopyTo(nonce, nonce.Length - sizeof(long));
+        BinaryPrimitives.WriteInt64LittleEndian(nonce.AsSpan(nonce.Length - sizeof(long)), value);
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.File.Encrypt.Core/Models/HeaderMetadata.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Core/Models/HeaderMetadata.cs
@@ -14,13 +14,14 @@ internal static class HeaderMetadata
 
     /// <summary>
     /// Version 1 AES key length in bytes. This is the length of the AES key that will be encrypted and stored in the header.
+    /// Derived from <see cref="EncryptionConstants.SessionKeyLength"/> to keep a single source of truth.
     /// </summary>
-    public const int AesKeyLength = 32;
+    public const int AesKeyLength = EncryptionConstants.SessionKeyLength;
 
     /// <summary>
-    /// Version 1 nonce length.
+    /// Version 1 nonce length. Derived from <see cref="EncryptionConstants.NonceLength"/> to keep a single source of truth.
     /// </summary>
-    public const int NonceLength = 12;
+    public const int NonceLength = EncryptionConstants.NonceLength;
 
     /// <summary>
     /// The padding scheme used for RSA in the version 1 header.

--- a/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
@@ -147,12 +147,13 @@ public sealed class LogWriter : Stream
     public override bool CanWrite => true;
 
     /// <summary>
-    /// The length of the underlying stream. This may not reflect the actual length of the encrypted log data until after flushing, as data is buffered for encryption.
+    /// The length, in bytes, of the underlying (encrypted) stream. Each write is encrypted and forwarded to the
+    /// underlying stream immediately, so this reflects the encrypted bytes written so far, not the plaintext length.
     /// </summary>
     public override long Length => _inner.Length;
 
     /// <summary>
-    /// The current position within the buffered log data.
+    /// The current position within the underlying (encrypted) stream.
     /// </summary>
     /// <exception cref="NotSupportedException">
     /// Setting the position is not supported on <see cref="LogWriter"/> as it is designed for sequential writes.
@@ -164,7 +165,8 @@ public sealed class LogWriter : Stream
     }
 
     /// <summary>
-    /// Flushes the buffered log data by encrypting it and writing it to the underlying stream. After flushing, the buffer is cleared.
+    /// Flushes the underlying stream. Each write is encrypted and forwarded immediately, so the writer itself
+    /// buffers no plaintext; this simply flushes the underlying stream to disk.
     /// </summary>
     public override void Flush()
     {
@@ -185,7 +187,8 @@ public sealed class LogWriter : Stream
         throw new NotSupportedException();
 
     /// <summary>
-    /// Disposes the stream by flushing any remaining buffered log data, encrypting it, and writing it to the underlying stream before disposing of the inner stream.
+    /// Flushes and disposes the underlying stream, disposes the AES-GCM instance, and wipes the session key
+    /// and nonce from memory. No plaintext is buffered by the writer, so there is nothing further to encrypt.
     /// </summary>
     /// <param name="disposing"></param>
     protected override void Dispose(bool disposing)

--- a/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt/LogWriter.cs
@@ -166,7 +166,7 @@ public sealed class LogWriter : Stream
 
     /// <summary>
     /// Flushes the underlying stream. Each write is encrypted and forwarded immediately, so the writer itself
-    /// buffers no plaintext; this simply flushes the underlying stream to disk.
+    /// buffers no plaintext; this simply flushes the underlying stream.
     /// </summary>
     public override void Flush()
     {

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
@@ -3,6 +3,20 @@ namespace Serilog.Sinks.File.Encrypt.Tests;
 public class CryptographicUtilsTests : EncryptionTestBase
 {
     [Fact]
+    public void IncreaseNonce_IncrementsCounterAsLittleEndian()
+    {
+        // Arrange - 12-byte nonce; the first 4 bytes are fixed, the last 8 are the counter.
+        byte[] nonce = new byte[EncryptionConstants.NonceLength];
+
+        // Act
+        nonce.IncreaseNonce();
+
+        // Assert - counter == 1 stored little-endian in the last 8 bytes, regardless of host endianness.
+        byte[] expected = [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0];
+        nonce.ShouldBe(expected);
+    }
+
+    [Fact]
     public void InitializeRsa_FromXml_ReturnsInitializedRsaInstance()
     {
         // Arrange, Act


### PR DESCRIPTION
Closes #81.

Grab-bag of documentation/cosmetic cleanups from the review. No behavior changes; the wire format and all constant values are unchanged.

## Changes

- **`LogWriter`** — corrected the `Flush`/`Length`/`Position`/`Dispose` XML docs, which described a non-existent internal plaintext buffer ("data is buffered for encryption", "the buffer is cleared"). Each write is encrypted and forwarded to the underlying stream immediately.
- **`CryptographicUtils.IncreaseNonce`** — fixed the summary ("last 12 bytes" → last 8 bytes, a 64-bit little-endian counter, advanced in lockstep by both sides) and replaced the `1 % long.MaxValue` no-op with a plain `+ 1`.
- **`CryptographicUtils.MagicBytes`** — added a `<remarks>` warning that the array must be treated as read-only (only the reference is `readonly`, not its elements). A type change to truly enforce immutability would be a binary-breaking change, so it'\''s documented here and left for a future major version.
- **`HeaderMetadata`** — `AesKeyLength`/`NonceLength` now derive from `EncryptionConstants.SessionKeyLength`/`NonceLength` (kept as `const`, initialized from the other `const`) to remove the duplicated `32`/`12` literals and the drift risk. Both types are internal.

## Verification

`dotnet make` is green end-to-end (Lint, warnings-as-errors Build, Test, Package). Existing nonce round-trip / multi-message decryption tests continue to exercise `IncreaseNonce`; the constant values are unchanged so all format-dependent tests pass.