### PR TITLE
Add Claude Code project setup: CLAUDE.md, scoped rules, skills, line-ending policy

### DIFF
--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "src/Serilog.Sinks.File.Encrypt.Cli/**"
+  - "tests/Serilog.Sinks.File.Encrypt.Cli.Tests/**"
+---
+
+# CLI project rules
+
+The CLI ships as the `serilog-encrypt` tool, built on **Spectre.Console.Cli** with
+Microsoft.Extensions.DependencyInjection.
+
+## Structure
+
+- `Program.cs` is intentionally minimal: build registrar → `CommandApp` → run. All setup
+  lives in `Infrastructure/CommandAppConfiguration.cs` (command registration) and
+  `Infrastructure/ServiceCollectionExtensions.AddCliServices()` (DI registrations).
+- `Infrastructure/TypeRegistrar.cs` / `TypeResolver.cs` bridge Spectre.Console.Cli and
+  MS.DI — commands and their dependencies are constructor-injected.
+- Commands live in `Commands/` (`GenerateCommand`, `DecryptCommand`); supporting logic goes
+  in `Services/` behind an interface (`IInputResolver`/`IOutputResolver` pattern).
+
+## Conventions
+
+- **All file access goes through `System.IO.Abstractions.IFileSystem`** (injected; tests pass
+  a mock via `CommandAppConfiguration.CreateRegistrar(fileSystem)`). Never use `System.IO`
+  types directly in CLI code.
+- Command registration uses `.WithDescription()` and `.WithExample()`, and
+  `ValidateExamples()` is enabled — every example must remain a parseable invocation, and
+  new options should come with an example.
+- Adding a command: create it in `Commands/`, register services in `AddCliServices`, add it
+  in `CommandAppConfiguration.GetConfiguration()` with description + examples, and update
+  `resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md`.
+- Console output uses Spectre.Console markup; command return values are process exit codes
+  (0 = success, non-zero = failure).

--- a/.claude/rules/crypto-format.md
+++ b/.claude/rules/crypto-format.md
@@ -1,0 +1,58 @@
+---
+paths:
+  - "src/Serilog.Sinks.File.Encrypt.Core/**"
+  - "src/Serilog.Sinks.File.Encrypt/**"
+  - "src/Serilog.Sinks.File.Decrypt/**"
+---
+
+# Encrypted log format rules
+
+`src/Serilog.Sinks.File.Encrypt.Core/EncryptionConstants.cs` is the single source of truth
+for all wire-format constants. Read it before reasoning about the format; do not restate its
+values from memory.
+
+## Format versions
+
+- **v1** — AES-GCM frames with no associated data and no seal. Read-only since v6.0.0; the
+  writer never emits it again. The reader must decrypt v1 files byte-for-byte forever.
+- **v2** (current) — every AES-GCM record binds 41 bytes of associated data:
+  `SHA-256(full session header)` (32) + frame sequence (8, big-endian, starts at 0) +
+  frame type (1). A clean close writes an authenticated end-of-log **seal record**
+  (marker `0xFF 0x42 0x32 0x53`, encrypted payload = final frame count as big-endian ulong).
+
+## Invariants that are easy to break
+
+- **The seal nonce is reserved**: initial session nonce counter − 1, NOT the writer's rolling
+  nonce. The reader's nonce only advances per successfully decrypted frame, so a
+  tail-truncated file would otherwise desync and report generic tamper instead of the precise
+  `SealCountMismatch` (declared N vs decrypted K) diagnostic.
+- **The seal's frame count lives in the encrypted payload, not the AAD** — a count divergence
+  must decrypt and be reportable, not surface as an opaque `CryptographicException`.
+- **Frame sequence starts at 0** and is independent of the nonce counter (which starts random).
+- **The header hash binds version + keyId + RSA payload**; the v2 header layout is
+  byte-identical to v1 except the version byte. No separate session-id field exists.
+- **Session poisoning**: any frame auth failure abandons the whole session; the reader resyncs
+  only at the next session header.
+- Seal semantics: `SealCountMismatch` always throws in `ThrowException` mode (positively
+  detected truncation); `Unsealed` throws only with `DecryptionOptions.RequireSealed`
+  (crash-tolerance trade-off). v1 sessions report `NotApplicable` and count as non-sealed
+  under `RequireSealed`.
+
+## Rules for changing the format
+
+- Any change to bytes on disk requires a **new format version** (v3): add a new constant,
+  bump `CurrentFormatVersion`, keep readers for every old version, and add frozen fixtures
+  for the outgoing version before the old writer disappears. Never mutate the meaning of an
+  existing version.
+- Threat-model limits are documented (v1: issue #82 / PR #92; v2: issue #83 / PR #93). An
+  attacker holding only the public key can still fabricate whole sessions — do not claim
+  origin authentication anywhere in docs or XML comments.
+
+## Project conventions
+
+- **Core stays dependency-free** (pure BCL crypto). If a change to Core needs a package,
+  the change belongs elsewhere.
+- Encrypt and Decrypt both depend only on Core; never reference one from the other.
+- Writers (`src/Serilog.Sinks.File.Encrypt/Writers/`) and readers
+  (`src/Serilog.Sinks.File.Decrypt/Readers/`) mirror each other (session/header/frame). A
+  change on one side almost always needs a symmetric change and tests on the other.

--- a/.claude/rules/examples-benchmarks.md
+++ b/.claude/rules/examples-benchmarks.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "examples/**"
+---
+
+# Examples and benchmarks rules
+
+- `examples/` is **intentionally excluded** from the Cake build (`build.cs` builds only
+  `src/**` and `tests/**`): example dependencies' vulnerability advisories or warnings must
+  not fail CI. Don't add examples to the pipeline; build them manually when you touch them:
+  `dotnet build examples/<Project>`.
+- Examples have their own `Directory.Build.props`/`Directory.Packages.props` tree — example
+  package versions are managed there, separately from `src/`.
+- `Example.Console` and `Example.WebApi` are runnable smoke tests of the public API
+  (`dotnet run` in the project directory). `KeyService` loads an embedded `public_key.xml`
+  resource — keys are baked in, nothing to generate.
+
+## Benchmarks
+
+- Run from `examples/Example.Benchmarks`: `dotnet run -c Release` — interactive menu with
+  four BenchmarkDotNet suites (EncryptedLogStream, SerilogFileSink, WebApiRequest,
+  BackgroundWorker) plus run-all. Always Release; Debug results are meaningless.
+- Run benchmarks when touching crypto hot paths: `LogWriter`, the frame/header/session
+  writers, or anything in Core called per log event.
+- The README's benchmark tables are refreshed from **idle-machine** runs (see commit
+  `a54897c`) — don't update them from a run taken while other work was executing, and
+  mention machine state when reporting numbers.

--- a/.claude/rules/packaging-release.md
+++ b/.claude/rules/packaging-release.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "build.cs"
+  - ".github/workflows/**"
+  - "resources/nuget/**"
+  - "src/**/*.csproj"
+  - "**/Directory.Packages.props"
+  - "**/Directory.Build.props"
+---
+
+# Packaging and release rules
+
+## Versioning and publishing
+
+- Versions come from **MinVer** (git tags) — never hand-edit a version in a csproj or props
+  file. A release = create a git tag + GitHub Release; `publish.yaml` then runs
+  `dotnet make publish` with a NuGet API key from OIDC login.
+- The `Publish-NuGet` task in `build.cs` is guarded with
+  `WithCriteria(BuildSystem.IsRunningOnGitHubActions)` — it cannot and should not run
+  locally. Local `dotnet make` stops at Package (nupkgs land in `./.artifacts/`).
+- Only `src/**` projects are packed; examples and tests never ship.
+
+## Project/package configuration
+
+- **Central package management**: `ManagePackageVersionsCentrally` is on. Add or bump
+  versions in the `Directory.Packages.props` of the right tree (`src/`, `tests/`,
+  `examples/`); `PackageReference` items carry no `Version=`.
+- `src/Directory.Build.props` defines the shared shipping config: C# 14, nullable, embedded
+  debug symbols + SourceLink, strong-name signing with `resources/serilog-sinks-file-encrypt.snk`,
+  Roslynator analyzers, NuGet metadata (logo, readme, MIT license). Changes there affect
+  every shipped package — treat edits as release-engineering changes.
+- Each package embeds its readme from `resources/nuget/<PackageId>.md` — update the matching
+  file whenever public API or usage changes.
+- `global.json` pins the SDK (10.0.100, rollForward latestFeature); CI installs 8.0.x and
+  10.0.x. Changing target frameworks is a policy decision (LTS-only) — raise it, don't do it.
+
+## CI expectations
+
+- `ci.yaml` = `dotnet tool restore` + `dotnet make` (default target: Package, which chains
+  Lint → Build → Test) + Codecov upload. Anything that fails `dotnet make` locally fails CI.
+- `codeql-analysis.yaml` does a raw `dotnet build` — it does not use the Cake script.
+- Warnings are errors in both `build.cs` (TreatAllWarningsAs Error) and the props — do not
+  suppress warnings to get green; fix them or discuss.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "tests/**"
+---
+
+# Testing rules
+
+## Stack and layout
+
+- xunit **v3** (`xunit.v3` packages), NSubstitute for mocking, Shouldly for assertions,
+  coverlet for coverage. Test settings in each project's `xunit.runner.json`.
+- `tests/Serilog.Sinks.File.Tests.Shared/` holds shared helpers — reuse before writing new ones:
+  - `EncryptionTestBase` — generates a throwaway RSA key pair, provides ready
+    `EncryptionOptions`/`DecryptionOptions`, tracks and disposes created streams.
+    `CreateEncryptedStream(messages)` returns a sealed (cleanly closed) v2 session.
+  - `V1TestStreamBuilder` — builds v1-format streams in memory for compat tests, so v1
+    scenarios never require touching the frozen fixtures.
+  - `TestUtils` — misc helpers.
+
+## Frozen v1 fixtures (critical)
+
+`tests/Serilog.Sinks.File.Decrypt.Tests/Fixtures/v1/` pins the v1 on-disk format as written
+by the shipping v5.x writer. Full policy in the `README.md` in that folder. Rules:
+
+- **Never regenerate, edit, re-encode, or reformat any file there.** If regeneration is ever
+  truly needed, it must be done from the `5.x` release tag's `LogWriter`.
+- `.gitattributes` marks fixtures `-text` and `.gitignore` carries a negation for
+  `tests/**/Fixtures/**/*.log` — don't "clean up" either; the `*.expected.txt` comparisons
+  are byte-exact and CRLF normalization breaks them.
+- The fixture key pair (`fixture-private-key.pem`/`fixture-public-key.pem`) is a dedicated
+  throwaway — not a secret, but never reuse it outside these fixtures.
+- Fixtures are copied to the output directory via `CopyToOutputDirectory=PreserveNewest`.
+
+New fixtures for the **current** format are fine — generate them with the current writer and
+commit them alongside an `.expected.txt`, following the v1 folder's naming pattern.
+
+## Running tests
+
+- Full pipeline (what CI runs): `dotnet make Test`.
+- Fast inner loop: `dotnet test tests/<Project>.Tests`.
+- Coverage: `dotnet make Test --collect-coverage` → cobertura + trx under
+  `./.coverage/<ProjectName>/`.
+- Tests run on both net8.0 and net10.0 — a fix verified on one TFM isn't done until both pass.

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: benchmark
+description: Run the BenchmarkDotNet suites in Example.Benchmarks and compare before/after results. Use when a change touches crypto hot paths (LogWriter, Writers/, Core) or when asked to benchmark or update README performance numbers.
+---
+
+# Run and compare benchmarks
+
+Benchmarks live in `examples/Example.Benchmarks` (excluded from the Cake build — build/run
+them directly). The entry point is an interactive menu; pipe the selection in:
+
+```
+"1" | dotnet run -c Release --project examples/Example.Benchmarks
+```
+
+Selections: `1` EncryptedLogStream (low-level, the usual one for crypto changes),
+`2` SerilogFileSink comparison, `3` WebApiRequest, `4` BackgroundWorker, `5` all.
+Always `-c Release`; Debug numbers are meaningless. Results and reports land in
+`BenchmarkDotNet.Artifacts/` under the current directory.
+
+## Comparing before/after
+
+1. Run the relevant suite on the **baseline** (main): `git stash` or use a worktree
+   (`git worktree add`) so the branch code is not mixed in. Save the summary table.
+2. Run the same suite on the branch. Same machine, same power state.
+3. Report Mean, Allocated, and Gen0/1/2 side by side, with % delta. Call out anything
+   > ~5% Mean or any allocation growth on the per-log-event paths.
+
+## Ground rules
+
+- **Idle machine only** for numbers that will be published: no builds, browsers, or
+  background work during the run. Note machine state when reporting.
+- The README's benchmark tables are refreshed from idle-machine runs (see commit `a54897c`)
+  — never update them from a noisy run, and only update them when asked.
+- A full suite takes several minutes; run it in the background and check the output file.
+- The project targets net8.0 + net10.0, so `dotnet run` needs `-f net10.0` (or `net8.0`) to
+  pick a framework — state which one the numbers came from.

--- a/.claude/skills/format-bump/SKILL.md
+++ b/.claude/skills/format-bump/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: format-bump
+description: Guardrailed checklist for introducing a new on-disk format version (e.g. v3). Use when a change cannot avoid altering the encrypted log wire format - new fields, different AAD, header changes, new record types.
+---
+
+# Introduce a new on-disk format version
+
+A format bump is the highest-risk change in this repo: it is a breaking-compat event for
+every consumer and permanently adds a version the reader must support forever. Read
+`.claude/rules/crypto-format.md` and `EncryptionConstants.cs` first, and confirm with the
+user that a bump is truly unavoidable (many changes fit inside the current format).
+
+## Checklist (in order)
+
+1. **Design against the threat model.** Write the new layout down (AAD contents, nonce
+   discipline, seal semantics) and check it preserves the v2 guarantees: frame reorder/splice
+   detection, truncation fingerprinting (`SealCountMismatch`), crash tolerance (`Unsealed` vs
+   `RequireSealed`). Get the design agreed in a GitHub issue before coding (pattern: #83).
+2. **Freeze the outgoing format FIRST**: while the current writer still emits vN, generate
+   `Fixtures/v<N>/` fixtures using the `new-fixture` skill. This is the step that cannot be
+   done later.
+3. **Constants**: add `FormatVersionV<N+1>` to `EncryptionConstants.cs`, point
+   `CurrentFormatVersion` at it, add any new lengths/markers as named constants with XML
+   docs explaining the invariant (existing constants show the expected style).
+4. **Writer**: emit only the new version. Keep `Writers/` and `Readers/` symmetric.
+5. **Reader**: dispatch on the header version byte; every prior version keeps working —
+   never delete or alter old-version read paths.
+6. **Tests**: byte-exact fixture tests for the frozen vN set; integrity/tamper tests for the
+   new version (model on `V2IntegrityTests.cs`); seal/truncation semantics on both TFMs.
+   Run the `verify-v1-compat` skill — v1 must still pass untouched.
+7. **Docs**: update `.claude/rules/crypto-format.md`, `CHANGELOG.md` (breaking-changes
+   section with a compatibility matrix like the 6.0.0 entry), `SECURITY.md` if the threat
+   model moved, and the `resources/nuget/*.md` package docs.
+8. **Benchmark**: run the `benchmark` skill before/after — AAD or record layout changes hit
+   the per-log-event hot path.
+9. **Version**: this requires a major version bump (see the `release` skill when shipping).

--- a/.claude/skills/new-fixture/SKILL.md
+++ b/.claude/skills/new-fixture/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: new-fixture
+description: Generate and register a frozen on-disk format fixture (encrypted .log + .expected.txt pair) for backward-compatibility testing. Use before a format-version bump to freeze the outgoing format, or when a new compat scenario needs a pinned fixture.
+---
+
+# Create a frozen format fixture
+
+Fixtures pin an on-disk format exactly as a specific writer version produced it, so future
+readers can prove byte-exact backward compatibility. Model everything on the existing v1 set:
+`tests/Serilog.Sinks.File.Decrypt.Tests/Fixtures/v1/` and its `README.md`.
+
+## Procedure
+
+1. **Timing matters**: fixtures for format vN must be generated while the vN-emitting writer
+   is still the current code (e.g. freeze v2 fixtures BEFORE merging a v3 writer). Once the
+   writer is gone, regeneration requires checking out the old release tag.
+2. **Dedicated throwaway key pair** — never reuse the v1 fixture keys or any real key:
+   generate a fresh 2048-bit pair with `CryptographicUtils.GenerateRsaKeyPair()` (or the CLI
+   `generate` command) and commit both halves as `fixture-private-key.pem` /
+   `fixture-public-key.pem` in the new fixture folder. Document that they are not secrets.
+3. **Generate** with a one-off scratch program or temporary test using the real `LogWriter`
+   (see `Serilog.Sinks.File.Tests.Shared/EncryptionTestBase.CreateEncryptedStream` for the
+   pattern — dispose the writer so the session is sealed). Cover at least: a single session,
+   multiple appended sessions, and a non-empty `keyId`.
+4. **Write the pair**: `<scenario>.log` (encrypted bytes) and `<scenario>.expected.txt`
+   (exact plaintext the decryption must yield — byte-exact, LF endings, no trailing edits).
+5. **Register** in a `Fixtures/v<N>/` folder with a `README.md` copying the v1 README's
+   structure: what each file contains, the writer version/commit that produced them, and the
+   do-not-regenerate rule. Confirm the test csproj copies fixtures
+   (`<None Include="Fixtures\**\*" CopyToOutputDirectory="PreserveNewest" />` covers new
+   folders automatically).
+6. **Protecting the bytes**: `.gitattributes` already marks `tests/**/Fixtures/** -text` —
+   verify with `git check-attr text -- <new .log file>` (should say `unset`).
+7. **Prove them**: add or extend a decryption test that reads each fixture in
+   `ErrorHandlingMode.ThrowException` and compares byte-for-byte against `.expected.txt`
+   (see `V1Fixtures_DecryptByteExact_ReportNotApplicable` in `V2IntegrityTests.cs`).
+   Run it on both TFMs before committing.
+
+After committing, the fixtures are frozen: never regenerate, reformat, or re-encode them.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: release
+description: Cut a release - CHANGELOG finalization, GitHub Release with a MinVer semver tag, and NuGet publish verification. Use when asked to release, tag, or publish a new version (stable or preview).
+---
+
+# Release a new version
+
+Versioning is **MinVer**: the version comes from the git tag on the released commit. Tags are
+**bare semver with NO `v` prefix** (`5.0.0`, `6.0.0-preview.1`) — ignore the ancient `v*`
+tags in history. Publishing is fully automated: creating a GitHub Release triggers
+`.github/workflows/publish.yaml` → `dotnet make publish` → nuget.org (OIDC key, no secrets
+to handle). Never hand-edit version numbers anywhere.
+
+## Steps
+
+1. **Preconditions** — confirm before anything else:
+   - On `main`, up to date, clean tree; CI green for HEAD (`gh run list --branch main -L 3`).
+   - `gh release list -L 5` to see the latest version; pick the next one per semver
+     (breaking → major; preview suffix `-preview.N` for pre-releases).
+2. **CHANGELOG** (stable releases): change `## [X.Y.Z] - Unreleased` to the release date
+   (`## [X.Y.Z] - YYYY-MM-DD`). Follows Keep a Changelog. Commit via PR if branch protection
+   requires it. Previews can release with the section still `Unreleased`.
+3. **Confirm with the user** the exact version and target commit — a release is public and
+   publishes to nuget.org; it cannot be quietly undone.
+4. **Create the release** (this creates the tag):
+
+   ```
+   gh release create <version> --title "<version>" --notes "<summary or CHANGELOG excerpt>"
+   ```
+
+   Add `--prerelease` for `-preview.N` versions. Add `--target <sha>` if not releasing HEAD.
+5. **Verify the publish**: `gh run watch` the `publish.yaml` run, then confirm the packages
+   (Encrypt, Decrypt, Cli, Core) show the new version:
+
+   ```
+   dotnet package search Serilog.Sinks.File.Encrypt --exact-match --prerelease
+   ```
+
+## Notes
+
+- A failed publish run can be re-run from the release's workflow (`gh run rerun <id>`); do
+  not delete/recreate tags — nuget.org versions are immutable once pushed.
+- `MinVerSkip` is set for Debug builds — version checks must use Release builds.

--- a/.claude/skills/verify-v1-compat/SKILL.md
+++ b/.claude/skills/verify-v1-compat/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: verify-v1-compat
+description: Verify the frozen v1 fixtures are untouched and still decrypt byte-exact. Use after any change to Decrypt/Core code, before merging a branch that touches readers or the on-disk format, or when asked to check v1 backward compatibility.
+---
+
+# Verify v1 backward compatibility
+
+The v1 fixtures in `tests/Serilog.Sinks.File.Decrypt.Tests/Fixtures/v1/` are the only proof
+that the current reader still decrypts files written by the v5.x (v1-format) writer. This
+skill checks both halves of that guarantee: the fixture bytes are unmodified, and the reader
+still decrypts them byte-exact.
+
+## Steps
+
+1. **Fixture bytes unchanged in the working tree:**
+
+   ```
+   git status --porcelain -- tests/Serilog.Sinks.File.Decrypt.Tests/Fixtures/
+   ```
+
+   Must print nothing. Fixtures are `-text` in `.gitattributes`, so ANY entry here is a real
+   byte change — stop and report it; do not commit.
+
+2. **Fixture bytes unchanged vs main** (when on a branch):
+
+   ```
+   git diff main --name-only -- tests/Serilog.Sinks.File.Decrypt.Tests/Fixtures/
+   ```
+
+   Must print nothing. If a fixture differs from main, the branch has broken the compat gate.
+
+3. **Fixtures still decrypt byte-exact** (runs on both net8.0 and net10.0):
+
+   ```
+   dotnet test tests/Serilog.Sinks.File.Decrypt.Tests --filter "FullyQualifiedName~V1Fixtures"
+   ```
+
+   This runs `V1Fixtures_DecryptByteExact_ReportNotApplicable` in `V2IntegrityTests.cs`,
+   which decrypts every fixture and compares against its `.expected.txt` byte-for-byte.
+
+4. Report all three results explicitly. Pass = empty, empty, all tests green on both TFMs.
+
+## If something fails
+
+- Modified fixture bytes: restore them (`git restore <fixture path>` / from main) — never
+  regenerate with the current writer. Regeneration is only valid from the `5.x` release tag.
+- Failing decryption with unmodified fixtures: the reader regressed — this is a release
+  blocker, not a test to update.

--- a/.csharpierrc.json
+++ b/.csharpierrc.json
@@ -2,6 +2,6 @@
   "printWidth": 100,
   "useTabs": false,
   "tabWidth": 4,
-  "endOfLine": "lf"
+  "endOfLine": "auto"
 }
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -60,7 +60,6 @@ end_of_line = crlf
 ################################################################
 [*.cs]
 indent_size = 4
-end_of_line = crlf
 
 # Language version
 csharp_preferred_lang_version = 14

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Normalize all text files to LF in the repository regardless of each
+# contributor's core.autocrlf setting; working trees stay OS-native.
+* text=auto
+
 # Binary test fixtures pin exact on-disk bytes (including LF line endings inside
 # .expected.txt); they must never be line-ending normalized.
 tests/**/Fixtures/** -text

--- a/.gitignore
+++ b/.gitignore
@@ -492,3 +492,6 @@ $RECYCLE.BIN/
 
 # Claude Code personal settings (project skills/rules ARE committed)
 .claude/settings.local.json
+
+# [Rr]elease/ above is for build output; the release skill is source
+!.claude/skills/release/

--- a/.gitignore
+++ b/.gitignore
@@ -489,3 +489,6 @@ $RECYCLE.BIN/
 **/public_key.xml
 
 *.dotsettings.user
+
+# Claude Code personal settings (project skills/rules ARE committed)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+## Project Overview
+
+Serilog.Sinks.File.Encrypt is a hook for Serilog.Sinks.File that transparently encrypts log
+files using hybrid encryption (RSA key exchange + AES-256-GCM frames), plus a matching
+decryption library and a Spectre.Console CLI. MIT-licensed, published to NuGet.
+
+- Targets **net8.0 + net10.0** (LTS releases only). C# 14, nullable enabled, implicit usings.
+- Warnings are errors; assemblies are strong-named; versioning is **MinVer** from git tags.
+- **Central package management**: versions live in `Directory.Packages.props` per tree
+  (`src/`, `tests/`, `examples/`) — never put `Version=` on a `PackageReference`.
+
+## Repository Layout
+
+```
+build.cs                            # Cake.Sdk build script — run via `dotnet make`
+src/
+  Serilog.Sinks.File.Encrypt/      # Sink hook: EncryptHooks, LogWriter, Writers/
+  Serilog.Sinks.File.Decrypt/      # Decryption library: LogReader, Readers/
+  Serilog.Sinks.File.Encrypt.Core/ # Shared crypto primitives; EncryptionConstants.cs
+  Serilog.Sinks.File.Encrypt.Cli/  # `serilog-encrypt` CLI (Spectre.Console.Cli + DI)
+tests/                              # xunit.v3 + NSubstitute + Shouldly; Tests.Shared helpers
+examples/                           # Console, WebApi, Benchmarks — excluded from Cake build
+resources/nuget/                    # Per-package NuGet readme files
+.github/workflows/                  # ci.yaml, publish.yaml, codeql-analysis.yaml
+```
+
+## Architecture Notes
+
+- **The on-disk format is versioned**: v1 (legacy, read-only) and v2 (current: AAD-bound
+  frames + end-of-log seal). `src/Serilog.Sinks.File.Encrypt.Core/EncryptionConstants.cs` is
+  the source of truth. Any change to bytes on disk is a breaking-compat event — flag it
+  explicitly before touching the wire format.
+- **The Encrypt/Decrypt split is deliberate**: sink consumers never pull in decryption code.
+  Both depend only on Core; never add a reference between Encrypt and Decrypt.
+- **Core has zero external dependencies** — keep it that way.
+- **`tests/Serilog.Sinks.File.Decrypt.Tests/Fixtures/v1/` is frozen**: never regenerate or
+  modify these files; they are the v1 backward-compatibility gate (see the README there).
+- **Examples are intentionally excluded from the build pipeline** so their dependencies'
+  advisories can't fail CI — don't "fix" that.
+
+## Build, Test, Format
+
+One-time per clone: `dotnet tool restore` (installs `make`, `csharpier`, `husky`).
+
+- **Prefer `dotnet make` over raw `dotnet build`/`dotnet test`** — it runs the real pipeline
+  (Clean → Restore → Lint → Build → Test) with warnings-as-errors, matching CI exactly.
+  - `dotnet make Test` / `dotnet make Build` / `dotnet make Lint`; default target = Package.
+  - Args: `--configuration=Debug|Release` (default Release), `--collect-coverage`
+    (→ `./.coverage`).
+- Raw `dotnet test tests/<project>` is fine for a fast inner loop on one test project.
+- **Format with CSharpier**: `dotnet csharpier format <paths>` (config in `.csharpierrc.json`:
+  printWidth 100, 4-space indent). Husky pre-commit formats staged files automatically.
+- **Line endings are OS-native in the working tree** and normalized to LF in git
+  (`* text=auto` in `.gitattributes`; CSharpier `endOfLine: auto`). Keep a file's existing
+  endings when editing; never hand-normalize line endings — git does it at commit.
+- The Lint target additionally runs `dotnet format style --verify-no-changes` — run both
+  CSharpier and `dotnet make Lint` before considering work done.
+- Style rules enforced as errors: file-scoped namespaces, usings outside namespace,
+  `_camelCase` private fields.
+- SDK is pinned in `global.json` (10.0.100, rollForward latestFeature).
+
+## Pre-Change Workflow
+
+Before writing any code:
+
+1. **Read the GitHub issue first.** If the task references an issue (or likely has one), run
+   `gh issue view <n>` and read it fully before planning.
+2. **Ask before deciding.** When a design decision comes up, present the options and clearly
+   label which is **best practice** and which is merely **easiest**, with a one-line
+   trade-off for each. Never silently pick one.
+3. **Ask about missing information** instead of assuming — especially public-API impact,
+   on-disk format impact, and net8.0 vs net10.0 behavior differences.
+4. **Plan verification before implementing.** State which tests cover the change (existing
+   or new, and in which test project), whether an example or benchmark run is warranted, and
+   the v1/v2 compatibility implications if the format is touched.
+5. Implement, then finish with `dotnet csharpier format <changed paths>` and
+   `dotnet make Test`.
+
+## Releases & CI
+
+- CI (`ci.yaml`) runs `dotnet tool restore` + `dotnet make` on PRs and pushes to main.
+- Publishing happens on GitHub Release via `publish.yaml` → `dotnet make publish`.
+- Versions come from MinVer git tags — never hand-edit version numbers.
+- Update `CHANGELOG.md` for user-visible changes; per-package docs live in `resources/nuget/`.


### PR DESCRIPTION
## Summary

Sets up Claude Code project configuration and fixes the line-ending config mismatch it surfaced.

- **CLAUDE.md** (repo root): lean project guide - layout, `dotnet make` / CSharpier tooling, pre-change planning workflow, release basics. Deep detail is deferred to path-scoped rules so it only loads when relevant files are touched.
- **`.claude/rules/`** (5 files, loaded contextually via `paths:` globs): crypto wire-format invariants, testing/fixture freeze policy, CLI conventions, examples/benchmarks, packaging/release.
- **`.claude/skills/`** (5 skills): `verify-v1-compat`, `release`, `benchmark`, `new-fixture`, `format-bump` - codify the repo's risky or rarely-run procedures.
- **Line-ending policy**: working trees are OS-native, git stores LF.
  - `.gitattributes`: `* text=auto` pins LF normalization repo-side instead of relying on each contributor's `core.autocrlf` (index was verified already 100% LF - no renormalization churn).
  - `.csharpierrc.json`: `endOfLine: lf` -> `auto`, so CSharpier stops fighting CRLF checkouts on Windows (tree-wide `csharpier check .` previously failed on 98 files there).
  - `.editorconfig`: drop hard-coded `end_of_line = crlf` for `*.cs`.
- **`.gitignore`**: ignore `.claude/settings.local.json` (personal); negate `[Rr]elease/` for `.claude/skills/release/` (the VS build-output pattern was silently swallowing the skill directory).

## Verification

- `dotnet make Test` green end-to-end: Lint + build (warnings-as-errors) + 227 tests x net8.0/net10.0.
- Tree-wide `dotnet csharpier check .` passes on a Windows CRLF checkout (failed before the config change).
- `verify-v1-compat` skill's test filter validated: selects exactly the 3 v1 fixture decrypt tests, green on both TFMs.
- Path-scoped rule loading confirmed in a fresh session (reading a Core file injects `crypto-format.md`).