### PR TITLE
Fix #96: CLI exit-code contract, --quiet/--verbose, console writer seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,18 @@ new EncryptionOptions(rsa, KeyId: "my-key");
 - Internal writer/reader interfaces (`IFrameWriter`, `ISessionWriter`, `ISessionReader`) changed
   signatures.
 
+#### CLI exit-code contract ([#96](https://github.com/byte2pixel/serilog-sinks-file-encrypt/issues/96))
+
+The `serilog-encrypt` CLI now returns distinct exit codes so scripts can react without parsing
+output: `0` success, `1` runtime failure, `2` usage error (parse/validation failures previously
+surfaced as `-1`), `3` no input files matched (previously `0`). When several apply across a
+multi-file run, the highest-priority code wins (`1` > `3`).
+
 ### New Features
 
+- **CLI `--quiet` / `--verbose`** — both commands accept `-q|--quiet` (suppress informational
+  output; warnings and errors still shown) and `-v|--verbose` (adds per-file
+  session/message/resync diagnostic detail).
 - **Per-session seal verification** — `DecryptionResult.Sessions` reports each session's
   `SealStatus`: `Sealed`, `Unsealed` (crash *or* truncation — indistinguishable by design),
   `SealCountMismatch` (tail truncation of a sealed log), `SealInvalid` (tampering), or

--- a/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
+++ b/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
@@ -44,6 +44,8 @@ serilog-encrypt generate --output ./keys
 - `-o|--output <OUTPUT>` (required): The directory where the key files will be saved
 - `-k|--key-size <KEY_SIZE>` (optional): The size of the RSA key in bits (default: 2048)
 - `-f|--format <FORMAT>` (optional): The encoding format (Xml or Pem) for the RSA keys (default: Xml)
+- `-q|--quiet`: Suppress informational output (warnings and errors are still shown)
+- `-v|--verbose`: Show additional diagnostic detail
 
 This creates two files:
 - `private_key.xml`: The private key used for decryption (keep secure)
@@ -83,6 +85,21 @@ serilog-encrypt decrypt "logs/*.log" -k private_key.xml -o ./decrypted
 - `-s|--strict`: Fail immediately on first decryption error (default: continues processing all files)
 - `--require-sealed`: Treat sessions without a verified end-of-log seal (crashed, truncated, or v1-format) as errors. Combine with `--strict` to fail the file instead of only warning.
 - `--audit-log <PATH>`: Write detailed audit information to a rolling log file (max 10 MB, 7 retained files). If omitted, a randomly-named file is created in the temp directory.
+- `-q|--quiet`: Suppress informational output (warnings and errors are still shown)
+- `-v|--verbose`: Show additional diagnostic detail (per-file session/message/resync counts)
+
+**Exit codes (v6.0.0+):**
+
+Scripts can rely on the exit code to distinguish failure modes without parsing output:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — all matched files were processed |
+| 1 | Runtime failure — at least one file failed (IO, cryptography, access denied) |
+| 2 | Usage error — invalid arguments, missing key file |
+| 3 | No input files matched the path or glob pattern |
+
+When several conditions apply across a multi-file run, the highest-priority code wins: 1 > 3.
 
 **Features:**
 - Memory-optimized for large log files

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Security.Cryptography;
 using Serilog.Sinks.File.Decrypt;
 using Serilog.Sinks.File.Decrypt.Models;
+using Serilog.Sinks.File.Encrypt.Cli.Infrastructure;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -12,13 +13,13 @@ namespace Serilog.Sinks.File.Encrypt.Cli.Commands;
 /// <summary>
 /// Command to decrypt an encrypted log file using an RSA private key
 /// </summary>
-/// <param name="console">The ANSI console</param>
+/// <param name="writer">The verbosity-aware console writer</param>
 /// <param name="fileSystem">The file system</param>
 /// <param name="inputResolver">The service that resolves file paths from input (supports files, directories, and glob patterns)</param>
 /// <param name="outputResolver">The service that resolves the output path where the decrypted file will be saved.</param>
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
 public sealed class DecryptCommand(
-    IAnsiConsole console,
+    IConsoleWriter writer,
     IFileSystem fileSystem,
     IInputResolver inputResolver,
     IOutputResolver outputResolver
@@ -27,7 +28,7 @@ public sealed class DecryptCommand(
     /// <summary>
     /// The settings for the DecryptCommand
     /// </summary>
-    public sealed class Settings : CommandSettings
+    public sealed class Settings : GlobalCommandSettings
     {
         /// <summary>
         /// The path to an encrypted log file or directory containing encrypted log files.
@@ -151,11 +152,10 @@ public sealed class DecryptCommand(
         CancellationToken cancellationToken
     )
     {
+        writer.Verbosity = settings.Verbosity;
         try
         {
-            console.MarkupLineInterpolated(
-                $"[blue]Reading private key from:[/] {settings.KeyFile}"
-            );
+            writer.Info($"[blue]Reading private key from:[/] {settings.KeyFile}");
             string rsaPrivateKey = await fileSystem.File.ReadAllTextAsync(
                 settings.KeyFile,
                 cancellationToken
@@ -165,15 +165,13 @@ public sealed class DecryptCommand(
 
             if (filesToDecrypt.Count == 0)
             {
-                console.MarkupLineInterpolated(
+                writer.Warning(
                     $"[yellow]⚠ No files found matching the specified path or pattern.[/]"
                 );
-                return 0;
+                return ExitCodes.NoFilesMatched;
             }
 
-            console.MarkupLineInterpolated(
-                $"[blue]Found {filesToDecrypt.Count} file(s) to decrypt[/]"
-            );
+            writer.Info($"[blue]Found {filesToDecrypt.Count} file(s) to decrypt[/]");
 
             // Configure streaming options based on user settings
             ErrorHandlingMode errorMode = settings.Strict
@@ -183,7 +181,7 @@ public sealed class DecryptCommand(
             string auditLog =
                 settings.AuditLogPath
                 ?? Path.Join(Path.GetTempPath(), Path.GetRandomFileName() + ".log");
-            console.MarkupLineInterpolated($"[dim]Audit log:[/] {auditLog}");
+            writer.Info($"[dim]Audit log:[/] {auditLog}");
             _logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.File(
@@ -205,7 +203,7 @@ public sealed class DecryptCommand(
                 RequireSealed = settings.RequireSealed,
             };
 
-            console.WriteLine();
+            writer.BlankLine();
 
             (int successCount, int failureCount) = await ProcessFilesAsync(
                 settings,
@@ -215,43 +213,41 @@ public sealed class DecryptCommand(
             );
 
             // Summary
-            console.WriteLine();
-            console.MarkupLine("[bold]Summary:[/]");
-            console.MarkupLineInterpolated($"  [green]✓ Success:[/] {successCount}");
+            writer.BlankLine();
+            writer.Info($"[bold]Summary:[/]");
+            writer.Info($"  [green]✓ Success:[/] {successCount}");
             if (failureCount > 0)
             {
-                console.MarkupLineInterpolated($"  [red]✗ Failed:[/] {failureCount}");
+                writer.Warning($"  [red]✗ Failed:[/] {failureCount}");
             }
 
             await Log.CloseAndFlushAsync();
-            return failureCount > 0 ? 1 : 0;
+            return failureCount > 0 ? ExitCodes.RuntimeFailure : ExitCodes.Success;
         }
         catch (IOException ex)
         {
-            console.MarkupLineInterpolated(
-                $"[red]✗ Error reading or writing files: {ex.Message}[/]"
-            );
-            return 1;
+            writer.Error($"[red]✗ Error reading or writing files: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
         catch (UnauthorizedAccessException ex)
         {
-            console.MarkupLineInterpolated($"[red]✗ Access denied: {ex.Message}[/]");
-            return 1;
+            writer.Error($"[red]✗ Access denied: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
         catch (CryptographicException ex)
         {
-            console.MarkupLineInterpolated($"[red]✗ Decryption failed: {ex.Message}[/]");
-            return 1;
+            writer.Error($"[red]✗ Decryption failed: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
         catch (FormatException ex)
         {
-            console.MarkupLineInterpolated($"[red]✗ Invalid key or file format: {ex.Message}[/]");
-            return 1;
+            writer.Error($"[red]✗ Invalid key or file format: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
         catch (InvalidOperationException ex)
         {
-            console.MarkupLineInterpolated($"[red]✗ Invalid file: {ex.Message}[/]");
-            return 1;
+            writer.Error($"[red]✗ Invalid file: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
     }
 
@@ -282,12 +278,12 @@ public sealed class DecryptCommand(
 
             if (fileSystem.File.Exists(outputFile))
             {
-                console.MarkupLineInterpolated($"[dim]{outputFile} will be overwritten.[/]");
+                writer.Info($"[dim]{outputFile} will be overwritten.[/]");
             }
 
             try
             {
-                console.MarkupLineInterpolated($"[cyan]⧗ Decrypting:[/] {inputFile}");
+                writer.Info($"[cyan]⧗ Decrypting:[/] {inputFile}");
 
                 string? outputDir = fileSystem.Path.GetDirectoryName(outputFile);
                 if (!string.IsNullOrEmpty(outputDir) && !fileSystem.Directory.Exists(outputDir))
@@ -308,30 +304,32 @@ public sealed class DecryptCommand(
 
                 if (result.FailedHeaders > 0 || result.FailedMessages > 0)
                 {
-                    console.MarkupLineInterpolated(
+                    writer.Warning(
                         $"[yellow]⚠ Decryption completed with {result.FailedHeaders} failed headers and {result.FailedMessages} failed messages.\nCheck audit log.[/]"
                     );
                 }
                 else
                 {
-                    console.MarkupLineInterpolated($"[green]✓ Decrypted:[/] {inputFile}");
+                    writer.Info($"[green]✓ Decrypted:[/] {inputFile}");
                 }
+
+                writer.Verbose(
+                    $"  [dim]sessions: {result.DecryptedSessions}, messages: {result.DecryptedMessages}, failed headers: {result.FailedHeaders}, failed messages: {result.FailedMessages}, resync attempts: {result.ResyncAttempts}[/]"
+                );
 
                 ReportSealStatus(result);
 
-                console.MarkupLineInterpolated($"  [dim]→ {outputFile}[/]");
+                writer.Info($"  [dim]→ {outputFile}[/]");
                 successCount++;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                console.MarkupLineInterpolated($"[red]✗ Failed:[/] {inputFile} - {ex.Message}");
+                writer.Error($"[red]✗ Failed:[/] {inputFile} - {ex.Message}");
                 failureCount++;
             }
             catch (CryptographicException ex)
             {
-                console.MarkupLineInterpolated(
-                    $"[red]✗ Decryption failed:[/] {inputFile} - {ex.Message}"
-                );
+                writer.Error($"[red]✗ Decryption failed:[/] {inputFile} - {ex.Message}");
                 failureCount++;
             }
         }
@@ -358,7 +356,7 @@ public sealed class DecryptCommand(
                     );
                     break;
                 case SealStatus.NotApplicable:
-                    console.MarkupLineInterpolated(
+                    writer.Info(
                         $"  [dim]• Session {session.Index} (v1): legacy format, completeness cannot be verified[/]"
                     );
                     _logger?.Information(
@@ -367,7 +365,7 @@ public sealed class DecryptCommand(
                     );
                     break;
                 case SealStatus.Unsealed:
-                    console.MarkupLineInterpolated(
+                    writer.Warning(
                         $"  [yellow]⚠ Session {session.Index}: UNSEALED — the log was truncated or the application did not close cleanly[/]"
                     );
                     _logger?.Warning(
@@ -377,7 +375,7 @@ public sealed class DecryptCommand(
                     );
                     break;
                 case SealStatus.SealCountMismatch:
-                    console.MarkupLineInterpolated(
+                    writer.Error(
                         $"  [red]✗ Session {session.Index}: seal count mismatch — seal declares {session.DeclaredFrameCount} frame(s), {session.DecryptedMessages} decrypted (tail truncated)[/]"
                     );
                     _logger?.Error(
@@ -388,7 +386,7 @@ public sealed class DecryptCommand(
                     );
                     break;
                 case SealStatus.SealInvalid:
-                    console.MarkupLineInterpolated(
+                    writer.Error(
                         $"  [red]✗ Session {session.Index}: invalid seal — the end of the session was tampered with or corrupted[/]"
                     );
                     _logger?.Error(
@@ -406,7 +404,7 @@ public sealed class DecryptCommand(
             && result.Sessions.All(s => s.SealStatus == SealStatus.Sealed)
         )
         {
-            console.MarkupLineInterpolated(
+            writer.Info(
                 $"  [green]✓ All {result.Sessions.Count} session(s) sealed and complete[/]"
             );
         }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GenerateCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GenerateCommand.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
+using Serilog.Sinks.File.Encrypt.Cli.Infrastructure;
 using Serilog.Sinks.File.Encrypt.Models;
-using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Serilog.Sinks.File.Encrypt.Cli.Commands;
@@ -10,16 +10,16 @@ namespace Serilog.Sinks.File.Encrypt.Cli.Commands;
 /// <summary>
 /// Generates a new RSA public/private key pair and saves them to the specified output path.
 /// </summary>
-/// <param name="console">The ANSI console.</param>
+/// <param name="writer">The verbosity-aware console writer.</param>
 /// <param name="fileSystem">The file system.</param>
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
-public sealed class GenerateCommand(IAnsiConsole console, IFileSystem fileSystem)
+public sealed class GenerateCommand(IConsoleWriter writer, IFileSystem fileSystem)
     : Command<GenerateCommand.Settings>
 {
     /// <summary>
     /// The settings for the GenerateCommand.
     /// </summary>
-    public sealed class Settings : CommandSettings
+    public sealed class Settings : GlobalCommandSettings
     {
         /// <summary>
         /// The output path to write the public/private key pair.
@@ -57,15 +57,14 @@ public sealed class GenerateCommand(IAnsiConsole console, IFileSystem fileSystem
         CancellationToken cancellationToken
     )
     {
+        writer.Verbosity = settings.Verbosity;
         try
         {
             // Ensure output directory exists
             if (!fileSystem.Directory.Exists(settings.OutputPath))
             {
                 fileSystem.Directory.CreateDirectory(settings.OutputPath);
-                console.MarkupLineInterpolated(
-                    $"[yellow]Created directory:[/] {settings.OutputPath}"
-                );
+                writer.Info($"[yellow]Created directory:[/] {settings.OutputPath}");
             }
 
             // Generate the RSA key pair
@@ -91,29 +90,29 @@ public sealed class GenerateCommand(IAnsiConsole console, IFileSystem fileSystem
             fileSystem.File.WriteAllText(publicKeyPath, keyPair.publicKey);
 
             // Output success message
-            console.MarkupLine("[green]✓ Successfully generated RSA key pair![/]");
-            console.WriteLine();
-            console.MarkupLineInterpolated($"[red]Private Key:[/] {privateKeyPath}");
-            console.MarkupLineInterpolated($"[yellow]Public Key:[/] {publicKeyPath}");
-            console.WriteLine();
-            console.MarkupLine("[yellow]⚠️  Keep your private key secure and never share it![/]");
+            writer.Info($"[green]✓ Successfully generated RSA key pair![/]");
+            writer.BlankLine();
+            writer.Info($"[red]Private Key:[/] {privateKeyPath}");
+            writer.Info($"[yellow]Public Key:[/] {publicKeyPath}");
+            writer.BlankLine();
+            writer.Warning($"[yellow]⚠️  Keep your private key secure and never share it![/]");
 
-            return 0;
+            return ExitCodes.Success;
         }
         catch (IOException ex)
         {
-            console.MarkupLineInterpolated($"[red]Error writing key files: {ex.Message}[/]");
-            return 1;
+            writer.Error($"[red]Error writing key files: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
         catch (UnauthorizedAccessException ex)
         {
-            console.MarkupLineInterpolated($"[red]Access denied to output path: {ex.Message}[/]");
-            return 1;
+            writer.Error($"[red]Access denied to output path: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
         catch (System.Security.Cryptography.CryptographicException ex)
         {
-            console.MarkupLineInterpolated($"[red]Error generating RSA key pair: {ex.Message}[/]");
-            return 1;
+            writer.Error($"[red]Error generating RSA key pair: {ex.Message}[/]");
+            return ExitCodes.RuntimeFailure;
         }
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GlobalCommandSettings.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GlobalCommandSettings.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Serilog.Sinks.File.Encrypt.Cli.Commands;
+
+/// <summary>
+/// Settings shared by every serilog-encrypt command: output verbosity control.
+/// </summary>
+public class GlobalCommandSettings : CommandSettings
+{
+    /// <summary>
+    /// Suppress informational output; warnings and errors are still written.
+    /// </summary>
+    [CommandOption("-q|--quiet")]
+    [Description("Suppress informational output (warnings and errors are still shown)")]
+    [DefaultValue(false)]
+    public bool Quiet { get; init; }
+
+    /// <summary>
+    /// Write additional diagnostic detail.
+    /// </summary>
+    [CommandOption("-v|--verbose")]
+    [Description("Show additional diagnostic detail")]
+    [DefaultValue(false)]
+    public bool Verbose { get; init; }
+
+    /// <summary>
+    /// The effective verbosity derived from <see cref="Quiet"/> and <see cref="Verbose"/>.
+    /// </summary>
+    public Verbosity Verbosity =>
+        Quiet ? Verbosity.Quiet
+        : Verbose ? Verbosity.Verbose
+        : Verbosity.Normal;
+
+    /// <inheritdoc />
+    public override ValidationResult Validate()
+    {
+        if (Quiet && Verbose)
+        {
+            return ValidationResult.Error("✗ Error: --quiet and --verbose cannot be combined.");
+        }
+
+        return base.Validate();
+    }
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
@@ -39,15 +39,20 @@ public static class CommandAppConfiguration
                 .WithDescription("Generate a new RSA key pair for log encryption")
                 .WithExample(Generate, "--output", "./keys")
                 .WithExample(Generate, "-o", "./keys", "-k", "4096")
-                .WithExample(Generate, "-o", "./keys", "-f", "Pem");
+                .WithExample(Generate, "-o", "./keys", "-f", "Pem")
+                .WithExample(Generate, "-o", "./keys", "--quiet");
 
             c.AddCommand<DecryptCommand>(Decrypt)
-                .WithDescription("Decrypt encrypted log files using an RSA private key")
+                .WithDescription(
+                    "Decrypt encrypted log files using an RSA private key. "
+                        + "Exit codes: 0 success, 1 runtime failure, 2 usage error, 3 no files matched."
+                )
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey)
                 .WithExample(Decrypt, "*.log", "-k", PrivateKey)
                 .WithExample(Decrypt, "logs/*.txt", "-k", PrivateKey, "--id", "")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "-o", "decrypted.log")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--strict")
+                .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--verbose")
                 .WithExample(Decrypt, "./logs/*.log", "-k", PrivateKey, "--audit-log", "audit.log");
             c.ValidateExamples();
         };

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ExitCodes.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ExitCodes.cs
@@ -1,0 +1,56 @@
+namespace Serilog.Sinks.File.Encrypt.Cli.Infrastructure;
+
+/// <summary>
+/// The process exit-code contract for the serilog-encrypt CLI. Scripts can rely on these
+/// values to distinguish failure modes without parsing console output.
+/// When several conditions apply across a multi-file run, the highest-priority code wins:
+/// <see cref="RuntimeFailure"/> &gt; <see cref="NothingDecrypted"/> &gt; <see cref="NotSealed"/>
+/// &gt; <see cref="NoFilesMatched"/>.
+/// </summary>
+public static class ExitCodes
+{
+    /// <summary>
+    /// All matched files were decrypted, or the key pair was generated.
+    /// </summary>
+    public const int Success = 0;
+
+    /// <summary>
+    /// At least one file failed with a runtime error (IO, cryptography, access denied,
+    /// or an unexpected exception).
+    /// </summary>
+    public const int RuntimeFailure = 1;
+
+    /// <summary>
+    /// The invocation itself was invalid: bad arguments, a missing key file, a refused
+    /// overwrite without --force, or a missing passphrase in a non-interactive session.
+    /// Spectre.Console.Cli parse and validation failures are normalized to this value.
+    /// </summary>
+    public const int UsageError = 2;
+
+    /// <summary>
+    /// No input files matched the given path or glob pattern.
+    /// </summary>
+    public const int NoFilesMatched = 3;
+
+    /// <summary>
+    /// A file produced no decrypted sessions and no messages — typically a wrong key,
+    /// a wrong key id, or a file that is not an encrypted log (#84).
+    /// </summary>
+    public const int NothingDecrypted = 4;
+
+    /// <summary>
+    /// --require-sealed was set and at least one session was not cryptographically
+    /// verified as sealed.
+    /// </summary>
+    public const int NotSealed = 5;
+
+    /// <summary>
+    /// Maps a raw Spectre.Console.Cli result to the documented contract: parse and
+    /// validation failures surface as negative values and become
+    /// <see cref="UsageError"/>; everything else passes through unchanged.
+    /// </summary>
+    /// <param name="spectreExitCode">The value returned by CommandApp.Run/RunAsync.</param>
+    /// <returns>The process exit code to return to the shell.</returns>
+    public static int Normalize(int spectreExitCode) =>
+        spectreExitCode < 0 ? UsageError : spectreExitCode;
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<IInputResolver, InputResolver>();
         services.TryAddTransient<IOutputResolver, OutputResolver>();
         services.TryAddSingleton(AnsiConsole.Console);
+        services.TryAddSingleton<IConsoleWriter, ConsoleWriter>();
         return services;
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Program.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Program.cs
@@ -6,4 +6,4 @@ CommandApp app = new(registrar);
 
 app.Configure(CommandAppConfiguration.GetConfiguration());
 
-return await app.RunAsync(args);
+return ExitCodes.Normalize(await app.RunAsync(args));

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/ConsoleWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/ConsoleWriter.cs
@@ -1,0 +1,53 @@
+using Spectre.Console;
+
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <summary>
+/// Default <see cref="IConsoleWriter"/> writing Spectre.Console markup to the injected
+/// console.
+/// </summary>
+/// <param name="console">The ANSI console to write to.</param>
+public sealed class ConsoleWriter(IAnsiConsole console) : IConsoleWriter
+{
+    /// <inheritdoc />
+    public Verbosity Verbosity { get; set; } = Verbosity.Normal;
+
+    /// <inheritdoc />
+    public void Info(FormattableString markup)
+    {
+        if (Verbosity != Verbosity.Quiet)
+        {
+            console.MarkupLineInterpolated(markup);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Verbose(FormattableString markup)
+    {
+        if (Verbosity == Verbosity.Verbose)
+        {
+            console.MarkupLineInterpolated(markup);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Warning(FormattableString markup)
+    {
+        console.MarkupLineInterpolated(markup);
+    }
+
+    /// <inheritdoc />
+    public void Error(FormattableString markup)
+    {
+        console.MarkupLineInterpolated(markup);
+    }
+
+    /// <inheritdoc />
+    public void BlankLine()
+    {
+        if (Verbosity != Verbosity.Quiet)
+        {
+            console.WriteLine();
+        }
+    }
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/IConsoleWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/IConsoleWriter.cs
@@ -1,0 +1,61 @@
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <summary>
+/// The output verbosity of a command run.
+/// </summary>
+public enum Verbosity
+{
+    /// <summary>Only warnings and errors are written.</summary>
+    Quiet,
+
+    /// <summary>Informational output plus warnings and errors (the default).</summary>
+    Normal,
+
+    /// <summary>Everything, including diagnostic detail.</summary>
+    Verbose,
+}
+
+/// <summary>
+/// Writes human-facing console output at a level, so commands honor --quiet/--verbose
+/// consistently. Warnings and errors are always written; informational output is dropped
+/// at <see cref="Cli.Verbosity.Quiet"/> and diagnostic output only appears at
+/// <see cref="Cli.Verbosity.Verbose"/>. Interpolated values are markup-escaped; markup in
+/// the literal text is honored.
+/// </summary>
+public interface IConsoleWriter
+{
+    /// <summary>
+    /// The verbosity for the current run. Commands set this from their settings before
+    /// writing any output.
+    /// </summary>
+    Verbosity Verbosity { get; set; }
+
+    /// <summary>
+    /// Writes an informational line. Dropped when <see cref="Verbosity"/> is Quiet.
+    /// </summary>
+    /// <param name="markup">The markup text to write.</param>
+    void Info(FormattableString markup);
+
+    /// <summary>
+    /// Writes a diagnostic line. Only written when <see cref="Verbosity"/> is Verbose.
+    /// </summary>
+    /// <param name="markup">The markup text to write.</param>
+    void Verbose(FormattableString markup);
+
+    /// <summary>
+    /// Writes a warning line. Always written.
+    /// </summary>
+    /// <param name="markup">The markup text to write.</param>
+    void Warning(FormattableString markup);
+
+    /// <summary>
+    /// Writes an error line. Always written.
+    /// </summary>
+    /// <param name="markup">The markup text to write.</param>
+    void Error(FormattableString markup);
+
+    /// <summary>
+    /// Writes a blank spacer line. Dropped when <see cref="Verbosity"/> is Quiet.
+    /// </summary>
+    void BlankLine();
+}

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/CommandTestBase.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/CommandTestBase.cs
@@ -13,6 +13,17 @@ public abstract class CommandTestBase : IDisposable
     protected readonly MockFileSystem FileSystem = new();
     protected readonly IFileSystem FileSystemSub = Substitute.For<IFileSystem>();
 
+    /// <summary>
+    /// A real ConsoleWriter wrapping <see cref="TestConsole"/>, so command output
+    /// assertions keep working against <c>TestConsole.Output</c>.
+    /// </summary>
+    protected ConsoleWriter Writer { get; }
+
+    protected CommandTestBase()
+    {
+        Writer = new ConsoleWriter(TestConsole);
+    }
+
     public void Dispose()
     {
         Dispose(true);

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/DecryptCommandTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/DecryptCommandTests.cs
@@ -127,7 +127,7 @@ public class DecryptCommandTests : CommandTestBase
     }
 
     [Fact]
-    public async Task GivenNoFilesToDecrypt_ExecuteAsync_ReturnsSuccessWithWarning()
+    public async Task GivenNoFilesToDecrypt_ExecuteAsync_ReturnsNoFilesMatchedWithWarning()
     {
         // Arrange
         string emptyDir = Path.Join("empty");
@@ -150,7 +150,7 @@ public class DecryptCommandTests : CommandTestBase
         );
 
         // Assert
-        result.ShouldBe(0); // Success (no files to process)
+        result.ShouldBe(ExitCodes.NoFilesMatched);
         TestConsole.Output.ShouldContain("⚠ No files found matching the specified path or pattern");
     }
 
@@ -580,10 +580,92 @@ public class DecryptCommandTests : CommandTestBase
 
     #endregion
 
+    [Fact]
+    public async Task ExecuteAsync_WithQuiet_SuppressesInfoButKeepsWarnings()
+    {
+        // Arrange
+        string decryptedFilePath = Path.Join("logs", "decrypted.log");
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new()
+        {
+            InputPath = EncryptedFile,
+            KeyFile = _privateKeyPath,
+            OutputPath = decryptedFilePath,
+            Quiet = true,
+        };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.Success);
+        FileSystem.File.Exists(decryptedFilePath).ShouldBeTrue();
+        TestConsole.Output.ShouldNotContain("Reading private key from:");
+        TestConsole.Output.ShouldNotContain("✓ Decrypted:");
+        TestConsole.Output.ShouldNotContain("Summary:");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithQuiet_StillShowsNoFilesWarning()
+    {
+        // Arrange
+        _inputResolver.ResolveFiles(Arg.Any<string>()).Returns(Enumerable.Empty<string>());
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new()
+        {
+            InputPath = "missing/*.log",
+            KeyFile = _privateKeyPath,
+            Quiet = true,
+        };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.NoFilesMatched);
+        TestConsole.Output.ShouldContain("⚠ No files found matching the specified path or pattern");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithVerbose_ShowsDecryptionDetail()
+    {
+        // Arrange
+        TestConsole.Profile.Width = 260; // keep the long verbose line from wrapping
+        string decryptedFilePath = Path.Join("logs", "decrypted.log");
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new()
+        {
+            InputPath = EncryptedFile,
+            KeyFile = _privateKeyPath,
+            OutputPath = decryptedFilePath,
+            Verbose = true,
+        };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.Success);
+        TestConsole.Output.ShouldContain("resync attempts:");
+        TestConsole.Output.ShouldContain("sessions: 1");
+    }
+
     private DecryptCommand GetSut(IFileSystem? fileSystem = null)
     {
         return new DecryptCommand(
-            TestConsole,
+            Writer,
             fileSystem ?? FileSystem,
             _inputResolver,
             _outputResolver

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/ExitCodesTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/ExitCodesTests.cs
@@ -1,0 +1,15 @@
+namespace Serilog.Sinks.File.Encrypt.Cli.Tests;
+
+public class ExitCodesTests
+{
+    [Theory]
+    [InlineData(-1, ExitCodes.UsageError)]
+    [InlineData(-99, ExitCodes.UsageError)]
+    [InlineData(ExitCodes.Success, ExitCodes.Success)]
+    [InlineData(ExitCodes.RuntimeFailure, ExitCodes.RuntimeFailure)]
+    [InlineData(ExitCodes.NoFilesMatched, ExitCodes.NoFilesMatched)]
+    public void Normalize_MapsSpectreResultsToContract(int raw, int expected)
+    {
+        ExitCodes.Normalize(raw).ShouldBe(expected);
+    }
+}

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GenerateCommandTests.cs
@@ -8,7 +8,7 @@ public class GenerateCommandTests : CommandTestBase
     public void Execute_WithDefaultSettings_GeneratesKeyPairSuccessfully()
     {
         // Arrange
-        GenerateCommand command = new(TestConsole, FileSystem);
+        GenerateCommand command = new(Writer, FileSystem);
         string outputPath = Path.Join("test-keys");
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
@@ -48,7 +48,7 @@ public class GenerateCommandTests : CommandTestBase
     public void Execute_WithXmlFormat_GeneratesKeyPairSuccessfully()
     {
         // Arrange
-        GenerateCommand command = new(TestConsole, FileSystem);
+        GenerateCommand command = new(Writer, FileSystem);
         string outputPath = Path.Join("test-keys");
         GenerateCommand.Settings settings = new()
         {
@@ -93,7 +93,7 @@ public class GenerateCommandTests : CommandTestBase
     public void Execute_WithPemFormat_GeneratesKeyPairSuccessfully()
     {
         // Arrange
-        GenerateCommand command = new(TestConsole, FileSystem);
+        GenerateCommand command = new(Writer, FileSystem);
         string outputPath = Path.Join("test-keys");
         GenerateCommand.Settings settings = new()
         {
@@ -146,7 +146,7 @@ public class GenerateCommandTests : CommandTestBase
             .Directory.When(d => d.CreateDirectory(Arg.Any<string>()))
             .Do(_ => throw new UnauthorizedAccessException("Access denied to create directory"));
 
-        GenerateCommand command = new(TestConsole, mockFs);
+        GenerateCommand command = new(Writer, mockFs);
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
         // Act
@@ -181,7 +181,7 @@ public class GenerateCommandTests : CommandTestBase
             .File.When(f => f.WriteAllText(privateKeyPath, Arg.Any<string>()))
             .Do(_ => throw new IOException("Disk full or write error"));
 
-        GenerateCommand command = new(TestConsole, mockFs);
+        GenerateCommand command = new(Writer, mockFs);
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
         // Act
@@ -204,7 +204,7 @@ public class GenerateCommandTests : CommandTestBase
         string outputPath = Path.Join("test-keys");
 
         // Use a real file system but an invalid key size that will cause CryptographicException
-        GenerateCommand command = new(TestConsole, FileSystem);
+        GenerateCommand command = new(Writer, FileSystem);
         GenerateCommand.Settings settings = new()
         {
             OutputPath = outputPath,
@@ -229,7 +229,7 @@ public class GenerateCommandTests : CommandTestBase
         // Arrange
         string outputPath = Path.Join("new-test-keys");
 
-        GenerateCommand command = new(TestConsole, FileSystem);
+        GenerateCommand command = new(Writer, FileSystem);
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
         FileSystem.Directory.Exists(outputPath).ShouldBeFalse();

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GlobalCommandSettingsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GlobalCommandSettingsTests.cs
@@ -1,0 +1,30 @@
+using Spectre.Console;
+
+namespace Serilog.Sinks.File.Encrypt.Cli.Tests;
+
+public class GlobalCommandSettingsTests
+{
+    [Fact]
+    public void Validate_QuietAndVerbose_ReturnsError()
+    {
+        GlobalCommandSettings settings = new() { Quiet = true, Verbose = true };
+
+        ValidationResult result = settings.Validate();
+
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldNotBeNull();
+        result.Message.ShouldContain("--quiet and --verbose cannot be combined");
+    }
+
+    [Theory]
+    [InlineData(false, false, Verbosity.Normal)]
+    [InlineData(true, false, Verbosity.Quiet)]
+    [InlineData(false, true, Verbosity.Verbose)]
+    public void Verbosity_DerivesFromFlags(bool quiet, bool verbose, Verbosity expected)
+    {
+        GlobalCommandSettings settings = new() { Quiet = quiet, Verbose = verbose };
+
+        settings.Validate().Successful.ShouldBeTrue();
+        settings.Verbosity.ShouldBe(expected);
+    }
+}

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/CliIntegrationTestBase.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/CliIntegrationTestBase.cs
@@ -1,4 +1,3 @@
-using Serilog.Sinks.File.Encrypt.Cli.Infrastructure;
 using Spectre.Console.Cli.Testing;
 
 namespace Serilog.Sinks.File.Encrypt.Cli.Tests.Integration;

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ExampleIntegrationTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ExampleIntegrationTests.cs
@@ -34,4 +34,32 @@ public class ExampleIntegrationTests : CliIntegrationTestBase
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("decrypt", result.Output);
     }
+
+    [Fact]
+    public async Task Generate_QuietAndVerbose_FailsValidationAsUsageError()
+    {
+        // Act
+        CommandAppResult result = await Tester.RunAsync(
+            ["generate", "-o", "keys", "-q", "-v"],
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert - Spectre reports validation failures as -1; Program normalizes to 2
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(ExitCodes.UsageError, ExitCodes.Normalize(result.ExitCode));
+        Assert.Contains("--quiet and --verbose cannot be combined", result.Output);
+    }
+
+    [Fact]
+    public async Task Generate_WithQuiet_ParsesAndSucceeds()
+    {
+        // Act
+        CommandAppResult result = await Tester.RunAsync(
+            ["generate", "-o", "keys", "-q"],
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert
+        Assert.Equal(ExitCodes.Success, result.ExitCode);
+    }
 }

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ServiceCollectionExtensionsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Serilog.Sinks.File.Encrypt.Cli.Infrastructure;
 using Spectre.Console;
 
 namespace Serilog.Sinks.File.Encrypt.Cli.Tests.Integration;
@@ -40,7 +39,7 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddCliServices_ShouldRegisterExactlyTwoServices()
+    public void AddCliServices_ShouldRegisterExpectedServices()
     {
         // Arrange
         ServiceCollection services = new();
@@ -49,7 +48,7 @@ public class ServiceCollectionExtensionsTests
         services.AddCliServices();
 
         // Assert - Verify no services are accidentally added or removed
-        services.Count.ShouldBe(4);
+        services.Count.ShouldBe(5);
 
         // Verify IFileSystem is registered
         services
@@ -72,6 +71,11 @@ public class ServiceCollectionExtensionsTests
             .FirstOrDefault(s => s.ServiceType == typeof(IOutputResolver))
             .ShouldNotBeNull()
             .And(x => x.Lifetime.ShouldBe(ServiceLifetime.Transient));
+
+        services
+            .FirstOrDefault(s => s.ServiceType == typeof(IConsoleWriter))
+            .ShouldNotBeNull()
+            .And(x => x.Lifetime.ShouldBe(ServiceLifetime.Singleton));
     }
 
     [Fact]
@@ -85,7 +89,7 @@ public class ServiceCollectionExtensionsTests
         services.AddCliServices();
 
         // Assert
-        services.Count.ShouldBe(4); // Should still only have 4 services, no duplicates
+        services.Count.ShouldBe(5); // Should still only have 5 services, no duplicates
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Usings.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Usings.cs
@@ -4,6 +4,7 @@ global using System.Security.Cryptography;
 global using System.Text;
 global using NSubstitute;
 global using Serilog.Sinks.File.Encrypt.Cli.Commands;
+global using Serilog.Sinks.File.Encrypt.Cli.Infrastructure;
 global using Shouldly;
 global using Spectre.Console.Cli;
 global using Spectre.Console.Testing;


### PR DESCRIPTION
Closes #96. First PR of the 6.0.0 CLI overhaul — establishes the exit-code contract and verbosity plumbing the later issues (#84 fix, #85 fix, #97–#100) build on.

## What changed

**Exit-code contract** (`Infrastructure/ExitCodes.cs`)

| Code | Meaning |
|---|---|
| 0 | Success |
| 1 | Runtime failure (IO/crypto/access/unexpected) on ≥1 file |
| 2 | Usage error — Spectre's negative parse/validation results are normalized in `Program.cs` via `ExitCodes.Normalize` |
| 3 | No input files matched (**breaking** — was 0) |
| 4–5 | Reserved; wired up by the #84 fix and the `--require-sealed` report work (#100) |

**`-q|--quiet` / `-v|--verbose`** — new `GlobalCommandSettings` base for both commands; mutually exclusive (validated). Quiet suppresses informational output but keeps warnings/errors; verbose adds per-file session/message/resync-attempt detail.

**`IConsoleWriter` seam** — all human output in both commands now flows through a verbosity-aware writer (`Services/ConsoleWriter`). This is the seam #100 reuses to route markup to stderr under `--json`.

**Docs** — nuget readme gains the exit-code table and new options; CHANGELOG 6.0.0 breaking + features sections updated.

## Breaking changes

- "No files matched" exits `3` instead of `0`.
- Parse/validation errors surface as `2` instead of `-1`.

## Tests

- `ExitCodesTests` (Normalize mapping), `GlobalCommandSettingsTests` (flag validation + verbosity derivation).
- `DecryptCommandTests`: no-match → 3, quiet suppresses info but keeps warnings, verbose shows decryption detail.
- Integration: `-q -v` conflict → usage error through real parsing; `-q` parses and succeeds.
- `dotnet make Test` green on net8.0 + net10.0 (72 CLI tests).
