### PR TITLE
Fix #97: passphrase-encrypted private keys, Pem/3072 generate defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,22 @@ surfaced as `-1`), `3` no input files matched (previously `0`), `4` nothing decr
 `0` — see below). When several apply across a multi-file run, the highest-priority code wins
 (`1` > `2` > `4` > `3`).
 
+#### CLI `generate`: passphrase-encrypted keys by default, PEM + 3072-bit defaults ([#97](https://github.com/byte2pixel/serilog-sinks-file-encrypt/issues/97))
+
+- The private key is now written as a **passphrase-encrypted PKCS#8 PEM** by default
+  (PBKDF2-SHA256, 600,000 iterations, AES-256-CBC). The passphrase is resolved from
+  `--passphrase-file` → `--passphrase-env` → the `SERILOG_ENCRYPT_PASSPHRASE` environment
+  variable → an interactive hidden prompt with confirmation. There is deliberately no
+  `--passphrase` argv option (shell-history/process-list leakage). An unencrypted key now
+  requires the explicit `--plaintext` flag.
+- Default format is **Pem** (was Xml); Xml remains readable forever but is legacy on the
+  write side and requires `--plaintext`. Default key size is **3072** bits (was 2048).
+- The `-k` short option now belongs exclusively to `decrypt --key`; use `--key-size` on
+  `generate` (was `-k|--key-size`).
+- Library: `CryptographicUtils.GenerateRsaKeyPair` default `format` changed Xml → Pem, and a
+  new passphrase overload `GenerateRsaKeyPair(int, KeyFormat, ReadOnlySpan<char>)` produces
+  encrypted PKCS#8 private keys (PEM only).
+
 #### CLI: overwriting output requires `--force`; output paths are containment-checked ([#85](https://github.com/byte2pixel/serilog-sinks-file-encrypt/issues/85))
 
 - `decrypt` no longer silently overwrites existing output files: without the new `-f|--force`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,33 @@ new EncryptionOptions(rsa, KeyId: "my-key");
 The `serilog-encrypt` CLI now returns distinct exit codes so scripts can react without parsing
 output: `0` success, `1` runtime failure, `2` usage error (parse/validation failures previously
 surfaced as `-1`), `3` no input files matched (previously `0`), `4` nothing decrypted (previously
-`0` — see below). When several apply across a multi-file run, the highest-priority code wins
-(`1` > `2` > `4` > `3`).
+`0` — see below), `5` `--require-sealed` not met. When several apply across a multi-file run, the
+highest-priority code wins (`1` > `2` > `4` > `5` > `3`).
+
+#### CLI `decrypt`: rich report, `--json`, and `--require-sealed` exit code ([#100](https://github.com/byte2pixel/serilog-sinks-file-encrypt/issues/100))
+
+- Human output now includes a per-file **session table** (Session | Version | KeyId |
+  Messages | Failed | Seal) and a run **summary table** (files, succeeded/failed/refused/
+  nothing-decrypted, total messages, resync attempts).
+- New **`--json`**: a machine-readable report on stdout (`schemaVersion: 1` with per-file
+  outcomes, per-session seal detail, summary, and the process exit code); all human text is
+  redirected to stderr so stdout stays parseable.
+- **Breaking:** `--require-sealed` now has teeth without `--strict` — when any session is not
+  cryptographically verified as sealed (v1 sessions count as unverified, matching the
+  library's `RequireSealed` semantics), the run exits `5` after reporting normally.
+  Exit-code precedence: `1` > `2` > `4` > `5` > `3`.
+
+#### CLI `decrypt`: encrypted private keys supported; `--key` default is now `private_key.pem` ([#98](https://github.com/byte2pixel/serilog-sinks-file-encrypt/issues/98))
+
+- `decrypt` accepts passphrase-encrypted PKCS#8 PEM private keys. The passphrase is resolved
+  from `--passphrase-file` → `--passphrase-env` → `SERILOG_ENCRYPT_PASSPHRASE` → interactive
+  prompt, and is only requested when the key file is actually encrypted.
+- **Breaking:** the `--key` default changed from `private_key.xml` to `private_key.pem`. When
+  the default is used and only `private_key.xml` exists, the error message points at it.
+- Library (additive, non-breaking): `LocalKeyProvider` gains passphrase constructor overloads,
+  and `CryptographicUtils` gains `FromString(key, passphrase)` plus `IsEncryptedPem(key)`.
+  The parameterless `FromString` now reports a clear "passphrase required" error for
+  encrypted keys.
 
 #### CLI `generate`: passphrase-encrypted keys by default, PEM + 3072-bit defaults ([#97](https://github.com/byte2pixel/serilog-sinks-file-encrypt/issues/97))
 
@@ -99,6 +124,11 @@ new `DecryptionResult.NothingDecrypted` property (additive, non-breaking).
 
 ### New Features
 
+- **CLI `generate` restricts private key file permissions** ([#99](https://github.com/byte2pixel/serilog-sinks-file-encrypt/issues/99)) —
+  the private key file is now owner-only: mode 600 on Unix (applied at creation time, so
+  there is no permissive window) and an owner-only DACL on Windows. The public key keeps
+  default permissions. If restriction fails, a warning is shown and generation still
+  succeeds.
 - **CLI `--quiet` / `--verbose`** — both commands accept `-q|--quiet` (suppress informational
   output; warnings and errors still shown) and `-v|--verbose` (adds per-file
   session/message/resync diagnostic detail).

--- a/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
+++ b/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
@@ -42,15 +42,27 @@ serilog-encrypt generate --output ./keys
 
 **Options:**
 - `-o|--output <OUTPUT>` (required): The directory where the key files will be saved
-- `-k|--key-size <KEY_SIZE>` (optional): The size of the RSA key in bits (default: 2048)
-- `-f|--format <FORMAT>` (optional): The encoding format (Xml or Pem) for the RSA keys (default: Xml)
+- `--key-size <KEY_SIZE>` (optional): The size of the RSA key in bits (default: 3072)
+- `-f|--format <FORMAT>` (optional): The encoding format (Pem or Xml) for the RSA keys (default: Pem). Xml is legacy — it has no encrypted representation and requires `--plaintext`.
+- `--passphrase-env <NAME>`: Read the private-key passphrase from the named environment variable
+- `--passphrase-file <PATH>`: Read the private-key passphrase from the first line of the given file
+- `--plaintext`: Write the private key unencrypted (required for Xml format)
 - `--force`: Overwrite existing key files. Without it, generation is refused when a key file already exists — overwriting a private key permanently loses access to all logs encrypted with it.
 - `-q|--quiet`: Suppress informational output (warnings and errors are still shown)
 - `-v|--verbose`: Show additional diagnostic detail
 
 This creates two files:
-- `private_key.xml`: The private key used for decryption (keep secure)
-- `public_key.xml`: The public key used for encryption
+- `private_key.pem`: The private key used for decryption (keep secure)
+- `public_key.pem`: The public key used for encryption
+
+**Passphrase protection (v6.0.0+):** by default the private key is written as a
+passphrase-encrypted PKCS#8 PEM (`ENCRYPTED PRIVATE KEY`, PBKDF2-SHA256 with 600,000
+iterations, AES-256-CBC). The passphrase is resolved in order from `--passphrase-file`,
+`--passphrase-env`, the `SERILOG_ENCRYPT_PASSPHRASE` environment variable, and finally an
+interactive hidden prompt (with confirmation). There is deliberately **no** `--passphrase`
+command-line option — secrets on the command line leak via shell history and process
+listings. In a non-interactive session with no passphrase source, generation fails (exit 2)
+unless `--plaintext` is passed. **There is no recovery if the passphrase is lost.**
 
 ### Decrypt Log Files
 

--- a/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
+++ b/resources/nuget/Serilog.Sinks.File.Encrypt.Cli.md
@@ -64,6 +64,10 @@ command-line option — secrets on the command line leak via shell history and p
 listings. In a non-interactive session with no passphrase source, generation fails (exit 2)
 unless `--plaintext` is passed. **There is no recovery if the passphrase is lost.**
 
+**File permissions (v6.0.0+):** the private key file is restricted to the current user —
+mode 600 on Unix (applied at creation, no permissive window) and an owner-only ACL on
+Windows. If the restriction fails, a warning is printed and generation still succeeds.
+
 ### Decrypt Log Files
 
 Decrypt encrypted log files using your RSA private key:
@@ -92,12 +96,14 @@ serilog-encrypt decrypt "logs/*.log" -k private_key.xml -o ./decrypted
 - `<PATH>`: Path to an encrypted log file, or a glob pattern (e.g., `*.log`, `logs/*.txt`). Directories are not accepted directly — append a pattern such as `logs/*.log`.
 
 **Options:**
-- `-k|--key <KEY>`: Path to the RSA private key file (default: `private_key.xml`)
+- `-k|--key <KEY>`: Path to the RSA private key file (default: `private_key.pem`). Passphrase-encrypted PKCS#8 PEM keys are supported.
+- `--passphrase-env <NAME>` / `--passphrase-file <PATH>`: Passphrase source for an encrypted private key; `SERILOG_ENCRYPT_PASSPHRASE` is checked as a fallback, then an interactive hidden prompt. Only consulted when the key file is actually encrypted.
 - `--id <KEY_ID>`: The key ID that was supplied to `EncryptHooks` during encryption (default: `""` — matches files encrypted without a key ID)
 - `-o|--output <OUTPUT>`: Output directory or file path (default: adds `.decrypted` to original filename)
 - `-f|--force`: Overwrite existing output files. Without it, a file whose output already exists is refused (skipped) and the run exits with code 2.
 - `-s|--strict`: Fail immediately on first decryption error (default: continues processing all files)
-- `--require-sealed`: Treat sessions without a verified end-of-log seal (crashed, truncated, or v1-format) as errors. Combine with `--strict` to fail the file instead of only warning.
+- `--require-sealed`: Treat sessions without a verified end-of-log seal (crashed, truncated, or v1-format) as errors: the run exits with code 5, or fails the file immediately when combined with `--strict`.
+- `--json`: Write a machine-readable JSON report to stdout (`schemaVersion: 1` — per-file outcomes, per-session seal status, run summary, exit code); all human-facing text goes to stderr so stdout stays parseable.
 - `--audit-log <PATH>`: Write detailed audit information to a rolling log file (max 10 MB, 7 retained files). If omitted, a randomly-named file is created in the temp directory.
 - `-q|--quiet`: Suppress informational output (warnings and errors are still shown)
 - `-v|--verbose`: Show additional diagnostic detail (per-file session/message/resync counts)
@@ -113,8 +119,9 @@ Scripts can rely on the exit code to distinguish failure modes without parsing o
 | 2 | Usage error — invalid arguments, missing key file, or an existing output file refused without `--force` |
 | 3 | No input files matched the path or glob pattern |
 | 4 | Nothing decrypted — a file produced no sessions and no messages (wrong key, wrong `--id`, or not an encrypted log); the empty output file is removed |
+| 5 | `--require-sealed` was set and at least one session is not cryptographically verified as sealed (v1 sessions count as unverified) |
 
-When several conditions apply across a multi-file run, the highest-priority code wins: 1 > 2 > 4 > 3.
+When several conditions apply across a multi-file run, the highest-priority code wins: 1 > 2 > 4 > 5 > 3.
 
 **Features:**
 - Memory-optimized for large log files

--- a/resources/nuget/Serilog.Sinks.File.Encrypt.md
+++ b/resources/nuget/Serilog.Sinks.File.Encrypt.md
@@ -162,12 +162,15 @@ For the decryption side of key rotation, see the [Serilog.Sinks.File.Decrypt doc
 ```csharp
 using Serilog.Sinks.File.Encrypt;
 
-// Generate a new RSA key pair
+// Generate a new RSA key pair (PEM by default in v6.0.0+)
 var (publicKey, privateKey) = CryptographicUtils.GenerateRsaKeyPair();
 
 // Save keys to files
-File.WriteAllText("public_key.xml", publicKey);
-File.WriteAllText("private_key.xml", privateKey);
+File.WriteAllText("public_key.pem", publicKey);
+File.WriteAllText("private_key.pem", privateKey);
+
+// Or generate a passphrase-protected private key (encrypted PKCS#8 PEM)
+var (pub, encryptedPriv) = CryptographicUtils.GenerateRsaKeyPair(3072, KeyFormat.Pem, "my passphrase");
 ```
 
 ### Web Application Example
@@ -195,8 +198,12 @@ app.Run();
 
 ### Key Management
 ```csharp
-// Generates a new RSA key pair with the specified key size and format (XML or PEM).
-(string publicKey, string privateKey) CryptographicUtils.GenerateRsaKeyPair(int keySize = 2048, KeyFormat format = KeyFormat.Xml)
+// Generates a new RSA key pair with the specified key size and format (PEM or XML).
+(string publicKey, string privateKey) CryptographicUtils.GenerateRsaKeyPair(int keySize = 2048, KeyFormat format = KeyFormat.Pem)
+
+// Generates a key pair whose private key is a passphrase-encrypted PKCS#8 PEM
+// (PBKDF2-SHA256, 600,000 iterations, AES-256-CBC). PEM format only.
+(string publicKey, string privateKey) CryptographicUtils.GenerateRsaKeyPair(int keySize, KeyFormat format, ReadOnlySpan<char> passphrase)
 ```
 
 ### Encryption Hook

--- a/src/Serilog.Sinks.File.Decrypt/LocalKeyProvider.cs
+++ b/src/Serilog.Sinks.File.Decrypt/LocalKeyProvider.cs
@@ -26,6 +26,20 @@ public sealed class LocalKeyProvider : IKeyProvider, IDisposable
     /// <exception cref="ArgumentException">Thrown if the provided keyMap is empty</exception>
     /// <exception cref="CryptographicException">Thrown if any of the RSA keys in the keyMap are invalid or cannot be parsed.</exception>
     public LocalKeyProvider(Dictionary<string, string> keyMap)
+        : this(keyMap, passphrase: null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalKeyProvider"/> class with a dictionary of key IDs
+    /// and their corresponding RSA private keys, where keys may be passphrase-encrypted PKCS#8 PEM
+    /// (<c>ENCRYPTED PRIVATE KEY</c> blocks). The same passphrase is applied to every encrypted key
+    /// in the map; unencrypted keys ignore it.
+    /// </summary>
+    /// <param name="keyMap">A dictionary mapping key IDs to their corresponding RSA private keys in string format.</param>
+    /// <param name="passphrase">The passphrase for encrypted keys, or null when no key is encrypted.</param>
+    /// <exception cref="ArgumentNullException">Thrown if the provided keyMap is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if the provided keyMap is empty</exception>
+    /// <exception cref="CryptographicException">Thrown if any RSA key is invalid, encrypted without a passphrase, or the passphrase is wrong.</exception>
+    public LocalKeyProvider(Dictionary<string, string> keyMap, string? passphrase)
     {
         ArgumentNullException.ThrowIfNull(keyMap);
         if (keyMap.Count == 0)
@@ -35,38 +49,48 @@ public sealed class LocalKeyProvider : IKeyProvider, IDisposable
 
         foreach ((string key, string rsa) in keyMap)
         {
-            try
-            {
-                var rsaKey = RSA.Create();
-                rsaKey.FromString(rsa);
-                _rsaKeyCache.Add(key, rsaKey);
-            }
-            catch (Exception ex)
-                when (ex is CryptographicException or ArgumentNullException or ArgumentException
-                    || ex.GetType().Name.Contains("CryptographicException")
-                )
-            {
-                throw new CryptographicException(
-                    $"Invalid RSA key for key ID '{key}': {ex.Message}",
-                    ex
-                );
-            }
+            _rsaKeyCache.Add(key, ImportKey(key, rsa, passphrase));
         }
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LocalKeyProvider"/> class with a single RSA key.
     /// </summary>
-    /// <param name="keyId"></param>
-    /// <param name="privateKey"></param>
-    /// <exception cref="CryptographicException"></exception>
+    /// <param name="keyId">The key id associated with the private key.</param>
+    /// <param name="privateKey">The RSA private key in XML or PEM format.</param>
+    /// <exception cref="CryptographicException">Thrown if the RSA key is invalid or cannot be parsed.</exception>
     public LocalKeyProvider(string keyId, string privateKey)
+        : this(keyId, privateKey, passphrase: null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalKeyProvider"/> class with a single RSA key
+    /// that may be a passphrase-encrypted PKCS#8 PEM (<c>ENCRYPTED PRIVATE KEY</c> block).
+    /// An unencrypted key ignores the passphrase.
+    /// </summary>
+    /// <param name="keyId">The key id associated with the private key.</param>
+    /// <param name="privateKey">The RSA private key in XML or PEM format, optionally encrypted.</param>
+    /// <param name="passphrase">The passphrase for an encrypted key, or null when the key is unencrypted.</param>
+    /// <exception cref="CryptographicException">Thrown if the RSA key is invalid, encrypted without a passphrase, or the passphrase is wrong.</exception>
+    public LocalKeyProvider(string keyId, string privateKey, string? passphrase)
+    {
+        _rsaKeyCache.Add(keyId, ImportKey(keyId, privateKey, passphrase));
+    }
+
+    private static RSA ImportKey(string keyId, string privateKey, string? passphrase)
     {
         try
         {
             var rsa = RSA.Create();
-            rsa.FromString(privateKey);
-            _rsaKeyCache.Add(keyId, rsa);
+            if (passphrase is null)
+            {
+                rsa.FromString(privateKey);
+            }
+            else
+            {
+                rsa.FromString(privateKey, passphrase);
+            }
+
+            return rsa;
         }
         catch (Exception ex)
             when (ex is CryptographicException or ArgumentNullException or ArgumentException

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
@@ -17,12 +17,16 @@ namespace Serilog.Sinks.File.Encrypt.Cli.Commands;
 /// <param name="fileSystem">The file system</param>
 /// <param name="inputResolver">The service that resolves file paths from input (supports files, directories, and glob patterns)</param>
 /// <param name="outputResolver">The service that resolves the output path where the decrypted file will be saved.</param>
+/// <param name="passphraseResolver">Resolves the private-key passphrase when the key file is encrypted.</param>
+/// <param name="reporter">Renders the per-file/session report tables and the --json payload.</param>
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
 public sealed class DecryptCommand(
     IConsoleWriter writer,
     IFileSystem fileSystem,
     IInputResolver inputResolver,
-    IOutputResolver outputResolver
+    IOutputResolver outputResolver,
+    IPassphraseResolver passphraseResolver,
+    IDecryptReporter reporter
 ) : AsyncCommand<DecryptCommand.Settings>
 {
     /// <summary>
@@ -40,11 +44,35 @@ public sealed class DecryptCommand(
         public string InputPath { get; init; } = string.Empty;
 
         /// <summary>
-        /// The path to the RSA private key file in XML or PEM format.
+        /// The default private key file name looked for when --key is not given.
+        /// </summary>
+        internal const string DefaultKeyFile = "private_key.pem";
+
+        /// <summary>
+        /// The path to the RSA private key file in XML or PEM format. Passphrase-encrypted
+        /// PKCS#8 PEM keys are supported; the passphrase is resolved from
+        /// --passphrase-file/--passphrase-env/SERILOG_ENCRYPT_PASSPHRASE or an interactive
+        /// prompt.
         /// </summary>
         [CommandOption("-k|--key <KEY>")]
-        [Description("The file containing the RSA private key in XML or PEM format")]
-        public string KeyFile { get; init; } = "private_key.xml";
+        [Description(
+            "The file containing the RSA private key in XML or PEM format (encrypted PKCS#8 PEM supported)"
+        )]
+        public string KeyFile { get; init; } = DefaultKeyFile;
+
+        /// <summary>
+        /// Name of an environment variable holding the private-key passphrase.
+        /// </summary>
+        [CommandOption("--passphrase-env <NAME>")]
+        [Description("Read the private-key passphrase from the named environment variable")]
+        public string? PassphraseEnv { get; init; }
+
+        /// <summary>
+        /// Path of a file whose first line is the private-key passphrase.
+        /// </summary>
+        [CommandOption("--passphrase-file <PATH>")]
+        [Description("Read the private-key passphrase from the first line of the given file")]
+        public string? PassphraseFile { get; init; }
 
         /// <summary>
         /// The id of the key to use for decryption. This should match exactly the key id used during encryption.
@@ -86,15 +114,27 @@ public sealed class DecryptCommand(
 
         /// <summary>
         /// Treat any session that is not cryptographically verified as sealed as an error.
-        /// Combined with --strict, an unsealed (crashed or truncated) or v1-format session
-        /// fails the file instead of only being reported.
+        /// On its own, an unsealed (crashed or truncated) or v1-format session makes the
+        /// run exit with code 5 after reporting normally; combined with --strict it fails
+        /// the file immediately.
         /// </summary>
         [CommandOption("--require-sealed")]
         [Description(
-            "Treat sessions without a verified end-of-log seal (crashed, truncated, or v1-format) as errors. Combine with --strict to fail the file."
+            "Treat sessions without a verified end-of-log seal (crashed, truncated, or v1-format) as errors: exit code 5, or an immediate failure with --strict."
         )]
         [DefaultValue(false)]
         public bool RequireSealed { get; init; }
+
+        /// <summary>
+        /// Emit a machine-readable JSON report on standard output; all human-facing text is
+        /// redirected to standard error.
+        /// </summary>
+        [CommandOption("--json")]
+        [Description(
+            "Write a machine-readable JSON report to stdout (schemaVersion 1); human output goes to stderr"
+        )]
+        [DefaultValue(false)]
+        public bool Json { get; init; }
 
         /// <summary>
         /// Path to write detailed audit information. If not specified, a temporary file will be used.
@@ -123,8 +163,15 @@ public sealed class DecryptCommand(
 
         if (!fileSystem.File.Exists(settings.KeyFile))
         {
+            // 6.0.0 changed the default from private_key.xml to private_key.pem — point
+            // users with an old key at the fix instead of a bare not-found error.
+            string hint =
+                settings.KeyFile == Settings.DefaultKeyFile
+                && fileSystem.File.Exists("private_key.xml")
+                    ? " Found 'private_key.xml' — pass -k private_key.xml to use it."
+                    : string.Empty;
             return ValidationResult.Error(
-                $"✗ Error: Key file '{settings.KeyFile}' does not exist."
+                $"✗ Error: Key file '{settings.KeyFile}' does not exist.{hint}"
             );
         }
 
@@ -162,6 +209,12 @@ public sealed class DecryptCommand(
     )
     {
         writer.Verbosity = settings.Verbosity;
+        if (settings.Json)
+        {
+            // Keep stdout clean for the JSON payload; humans read stderr.
+            writer.UseErrorChannel();
+        }
+
         try
         {
             writer.Info($"[blue]Reading private key from:[/] {settings.KeyFile}");
@@ -169,6 +222,35 @@ public sealed class DecryptCommand(
                 settings.KeyFile,
                 cancellationToken
             );
+
+            string? passphrase = null;
+            if (CryptographicUtils.IsEncryptedPem(rsaPrivateKey))
+            {
+                try
+                {
+                    passphrase = passphraseResolver.Resolve(
+                        settings.PassphraseFile,
+                        settings.PassphraseEnv,
+                        confirm: false
+                    );
+                }
+                catch (PassphraseResolutionException ex)
+                {
+                    writer.Error($"[red]✗ {ex.Message}[/]");
+                    return ExitCodes.UsageError;
+                }
+
+                if (passphrase is null)
+                {
+                    writer.Error(
+                        $"[red]✗ The private key is passphrase-encrypted but no passphrase source is available in a non-interactive session.[/]"
+                    );
+                    writer.Warning(
+                        $"[yellow]Provide --passphrase-env or --passphrase-file, or set {IPassphraseResolver.DefaultEnvironmentVariable}.[/]"
+                    );
+                    return ExitCodes.UsageError;
+                }
+            }
 
             IReadOnlyList<string> filesToDecrypt = inputResolver.ResolveFiles(settings.InputPath);
 
@@ -203,7 +285,7 @@ public sealed class DecryptCommand(
                 )
                 .CreateLogger();
 
-            LocalKeyProvider keyProvider = new(settings.KeyId, rsaPrivateKey);
+            LocalKeyProvider keyProvider = new(settings.KeyId, rsaPrivateKey, passphrase);
 
             DecryptionOptions decryptionOptions = new()
             {
@@ -214,41 +296,39 @@ public sealed class DecryptCommand(
 
             writer.BlankLine();
 
-            (int successCount, int failureCount, int zeroOutputCount, int refusedCount) =
-                await ProcessFilesAsync(
-                    settings,
-                    filesToDecrypt,
-                    decryptionOptions,
-                    cancellationToken
-                );
+            List<FileReport> fileReports = await ProcessFilesAsync(
+                settings,
+                filesToDecrypt,
+                decryptionOptions,
+                cancellationToken
+            );
+
+            RunSummary summary = BuildSummary(fileReports);
+            int exitCode = DetermineExitCode(settings, summary);
 
             // Summary
             writer.BlankLine();
-            writer.Info($"[bold]Summary:[/]");
-            writer.Info($"  [green]✓ Success:[/] {successCount}");
-            if (failureCount > 0)
+            reporter.ReportSummary(summary);
+            if (settings.RequireSealed && !summary.AllSessionsSealed)
             {
-                writer.Warning($"  [red]✗ Failed:[/] {failureCount}");
+                writer.Warning(
+                    $"[yellow]⚠ --require-sealed: at least one session is not cryptographically verified as sealed.[/]"
+                );
             }
-            if (refusedCount > 0)
+
+            if (settings.Json)
             {
-                writer.Warning($"  [yellow]⚠ Refused:[/] {refusedCount}");
-            }
-            if (zeroOutputCount > 0)
-            {
-                writer.Warning($"  [yellow]⚠ Nothing decrypted:[/] {zeroOutputCount}");
+                DecryptRunReport report = new(
+                    DecryptRunReport.CurrentSchemaVersion,
+                    fileReports,
+                    summary,
+                    exitCode
+                );
+                writer.Raw(reporter.ToJson(report) + Environment.NewLine);
             }
 
             await Log.CloseAndFlushAsync();
-            if (failureCount > 0)
-            {
-                return ExitCodes.RuntimeFailure;
-            }
-            if (refusedCount > 0)
-            {
-                return ExitCodes.UsageError;
-            }
-            return zeroOutputCount > 0 ? ExitCodes.NothingDecrypted : ExitCodes.Success;
+            return exitCode;
         }
         catch (IOException ex)
         {
@@ -285,22 +365,14 @@ public sealed class DecryptCommand(
     /// <param name="decryptionOptions">The decryption options.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns></returns>
-    private async Task<(
-        int successCount,
-        int failureCount,
-        int zeroOutputCount,
-        int refusedCount
-    )> ProcessFilesAsync(
+    private async Task<List<FileReport>> ProcessFilesAsync(
         Settings settings,
         IReadOnlyList<string> filesToDecrypt,
         DecryptionOptions decryptionOptions,
         CancellationToken cancellationToken
     )
     {
-        int successCount = 0;
-        int failureCount = 0;
-        int zeroOutputCount = 0;
-        int refusedCount = 0;
+        List<FileReport> reports = [];
         foreach (string inputFile in filesToDecrypt)
         {
             string outputFile;
@@ -317,7 +389,7 @@ public sealed class DecryptCommand(
                 // Path containment violation — refuse this file, keep processing the rest
                 writer.Error($"[red]✗ Refused:[/] {inputFile} - {ex.Message}");
                 _logger?.Error("Refused {InputFile}: {Reason}", inputFile, ex.Message);
-                refusedCount++;
+                reports.Add(EmptyReport(inputFile, null, FileOutcome.Refused, ex.Message));
                 continue;
             }
 
@@ -332,7 +404,14 @@ public sealed class DecryptCommand(
                         "Refused to overwrite existing output {OutputFile} without --force.",
                         outputFile
                     );
-                    refusedCount++;
+                    reports.Add(
+                        EmptyReport(
+                            inputFile,
+                            outputFile,
+                            FileOutcome.Refused,
+                            "Output file already exists (use --force to overwrite)."
+                        )
+                    );
                     continue;
                 }
 
@@ -376,7 +455,7 @@ public sealed class DecryptCommand(
                     );
                     fileSystem.File.Delete(outputFile);
                     writer.Info($"  [dim]Removed empty output file {outputFile}[/]");
-                    zeroOutputCount++;
+                    reports.Add(MapReport(inputFile, null, FileOutcome.NothingDecrypted, result));
                     continue;
                 }
 
@@ -395,24 +474,119 @@ public sealed class DecryptCommand(
                     $"  [dim]sessions: {result.DecryptedSessions}, messages: {result.DecryptedMessages}, failed headers: {result.FailedHeaders}, failed messages: {result.FailedMessages}, resync attempts: {result.ResyncAttempts}[/]"
                 );
 
+                FileReport report = MapReport(inputFile, outputFile, FileOutcome.Success, result);
+                reporter.ReportSessions(report);
                 ReportSealStatus(result);
 
                 writer.Info($"  [dim]→ {outputFile}[/]");
-                successCount++;
+                reports.Add(report);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 writer.Error($"[red]✗ Failed:[/] {inputFile} - {ex.Message}");
-                failureCount++;
+                reports.Add(EmptyReport(inputFile, outputFile, FileOutcome.Failed, ex.Message));
             }
             catch (CryptographicException ex)
             {
                 writer.Error($"[red]✗ Decryption failed:[/] {inputFile} - {ex.Message}");
-                failureCount++;
+                reports.Add(EmptyReport(inputFile, outputFile, FileOutcome.Failed, ex.Message));
             }
         }
 
-        return (successCount, failureCount, zeroOutputCount, refusedCount);
+        return reports;
+    }
+
+    private static FileReport MapReport(
+        string inputFile,
+        string? outputFile,
+        FileOutcome outcome,
+        DecryptionResult result
+    )
+    {
+        return new FileReport(
+            inputFile,
+            outputFile,
+            outcome,
+            result.DecryptedSessions,
+            result.DecryptedMessages,
+            result.FailedHeaders,
+            result.FailedMessages,
+            result.ResyncAttempts,
+            result.AllSessionsSealed,
+            result
+                .Sessions.Select(s => new SessionReport(
+                    s.Index,
+                    s.FormatVersion,
+                    s.KeyId,
+                    s.SealStatus.ToString(),
+                    s.DeclaredFrameCount,
+                    s.DecryptedMessages,
+                    s.FailedMessages
+                ))
+                .ToList(),
+            Error: null
+        );
+    }
+
+    private static FileReport EmptyReport(
+        string inputFile,
+        string? outputFile,
+        FileOutcome outcome,
+        string error
+    )
+    {
+        return new FileReport(
+            inputFile,
+            outputFile,
+            outcome,
+            DecryptedSessions: 0,
+            DecryptedMessages: 0,
+            FailedHeaders: 0,
+            FailedMessages: 0,
+            ResyncAttempts: 0,
+            AllSessionsSealed: true,
+            Sessions: [],
+            Error: error
+        );
+    }
+
+    private static RunSummary BuildSummary(List<FileReport> reports)
+    {
+        return new RunSummary(
+            reports.Count,
+            reports.Count(r => r.Outcome == FileOutcome.Success),
+            reports.Count(r => r.Outcome == FileOutcome.Failed),
+            reports.Count(r => r.Outcome == FileOutcome.Refused),
+            reports.Count(r => r.Outcome == FileOutcome.NothingDecrypted),
+            reports.Sum(r => r.DecryptedMessages),
+            reports.Sum(r => r.ResyncAttempts),
+            // Strict, matching the library's RequireSealed semantics: a v1 session
+            // (NotApplicable) cannot be verified and therefore counts as not sealed.
+            reports
+                .Where(r => r.Outcome == FileOutcome.Success)
+                .All(r => r.Sessions.All(s => s.SealStatus == nameof(SealStatus.Sealed)))
+        );
+    }
+
+    private static int DetermineExitCode(Settings settings, RunSummary summary)
+    {
+        if (summary.Failed > 0)
+        {
+            return ExitCodes.RuntimeFailure;
+        }
+        if (summary.Refused > 0)
+        {
+            return ExitCodes.UsageError;
+        }
+        if (summary.NothingDecrypted > 0)
+        {
+            return ExitCodes.NothingDecrypted;
+        }
+        if (settings.RequireSealed && !summary.AllSessionsSealed)
+        {
+            return ExitCodes.NotSealed;
+        }
+        return ExitCodes.Success;
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GenerateCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GenerateCommand.cs
@@ -3,18 +3,25 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Serilog.Sinks.File.Encrypt.Cli.Infrastructure;
 using Serilog.Sinks.File.Encrypt.Models;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Serilog.Sinks.File.Encrypt.Cli.Commands;
 
 /// <summary>
 /// Generates a new RSA public/private key pair and saves them to the specified output path.
+/// By default the private key is passphrase-encrypted (PKCS#8 PEM); pass --plaintext for a
+/// legacy unencrypted key.
 /// </summary>
 /// <param name="writer">The verbosity-aware console writer.</param>
 /// <param name="fileSystem">The file system.</param>
+/// <param name="passphraseResolver">Resolves the private-key passphrase from file, environment, or prompt.</param>
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
-public sealed class GenerateCommand(IConsoleWriter writer, IFileSystem fileSystem)
-    : Command<GenerateCommand.Settings>
+public sealed class GenerateCommand(
+    IConsoleWriter writer,
+    IFileSystem fileSystem,
+    IPassphraseResolver passphraseResolver
+) : Command<GenerateCommand.Settings>
 {
     /// <summary>
     /// The settings for the GenerateCommand.
@@ -31,17 +38,46 @@ public sealed class GenerateCommand(IConsoleWriter writer, IFileSystem fileSyste
         /// <summary>
         /// The size of the RSA key in bits.
         /// </summary>
-        [CommandOption("-k|--key-size <KEY_SIZE>")]
-        [Description("The size of the RSA key in bits (default: 2048)")]
-        [DefaultValue(2048)]
-        public int KeySize { get; init; } = 2048;
+        [CommandOption("--key-size <KEY_SIZE>")]
+        [Description("The size of the RSA key in bits (default: 3072)")]
+        [DefaultValue(3072)]
+        public int KeySize { get; init; } = 3072;
 
         /// <summary>
-        /// The export format for the RSA keys.
+        /// The export format for the RSA keys. Xml is legacy: it has no encrypted
+        /// representation and requires --plaintext.
         /// </summary>
         [CommandOption("-f|--format <FORMAT>")]
-        [Description("The encoding format (Xml or Pem) for the RSA keys (default: Xml)")]
-        public KeyFormat Format { get; init; } = KeyFormat.Xml;
+        [Description(
+            "The encoding format (Pem or Xml) for the RSA keys (default: Pem). Xml is legacy and requires --plaintext."
+        )]
+        public KeyFormat Format { get; init; } = KeyFormat.Pem;
+
+        /// <summary>
+        /// Name of an environment variable holding the private-key passphrase.
+        /// </summary>
+        [CommandOption("--passphrase-env <NAME>")]
+        [Description("Read the private-key passphrase from the named environment variable")]
+        public string? PassphraseEnv { get; init; }
+
+        /// <summary>
+        /// Path of a file whose first line is the private-key passphrase.
+        /// </summary>
+        [CommandOption("--passphrase-file <PATH>")]
+        [Description("Read the private-key passphrase from the first line of the given file")]
+        public string? PassphraseFile { get; init; }
+
+        /// <summary>
+        /// Write the private key unencrypted. Required for --format Xml. Without a
+        /// passphrase source, an interactive prompt is used; in a non-interactive session
+        /// the command fails unless this flag is set.
+        /// </summary>
+        [CommandOption("--plaintext")]
+        [Description(
+            "Write the private key unencrypted (required for Xml format). Default is a passphrase-encrypted PKCS#8 private key."
+        )]
+        [DefaultValue(false)]
+        public bool Plaintext { get; init; }
 
         /// <summary>
         /// Overwrite existing key files. Without this flag, generation is refused when a
@@ -52,6 +88,26 @@ public sealed class GenerateCommand(IConsoleWriter writer, IFileSystem fileSyste
         [Description("Overwrite existing key files (default: refuse if key files exist)")]
         [DefaultValue(false)]
         public bool Force { get; init; }
+
+        /// <inheritdoc />
+        public override ValidationResult Validate()
+        {
+            if (Format == KeyFormat.Xml && !Plaintext)
+            {
+                return ValidationResult.Error(
+                    "✗ Error: the Xml format cannot store an encrypted private key. Pass --plaintext to generate a legacy unencrypted Xml key, or use the Pem format."
+                );
+            }
+
+            if (Plaintext && (PassphraseEnv is not null || PassphraseFile is not null))
+            {
+                return ValidationResult.Error(
+                    "✗ Error: --plaintext cannot be combined with a passphrase source."
+                );
+            }
+
+            return base.Validate();
+        }
     }
 
     /// <summary>
@@ -106,11 +162,34 @@ public sealed class GenerateCommand(IConsoleWriter writer, IFileSystem fileSyste
                 }
             }
 
+            string? passphrase = null;
+            if (!settings.Plaintext)
+            {
+                passphrase = passphraseResolver.Resolve(
+                    settings.PassphraseFile,
+                    settings.PassphraseEnv,
+                    confirm: true
+                );
+                if (passphrase is null)
+                {
+                    writer.Error(
+                        $"[red]✗ No passphrase source available in a non-interactive session.[/]"
+                    );
+                    writer.Warning(
+                        $"[yellow]Provide --passphrase-env or --passphrase-file (or set {IPassphraseResolver.DefaultEnvironmentVariable}), or pass --plaintext to write an unencrypted private key.[/]"
+                    );
+                    return ExitCodes.UsageError;
+                }
+            }
+
             // Generate the RSA key pair
-            (string publicKey, string privateKey) keyPair = CryptographicUtils.GenerateRsaKeyPair(
-                settings.KeySize,
-                settings.Format
-            );
+            (string publicKey, string privateKey) keyPair = passphrase is null
+                ? CryptographicUtils.GenerateRsaKeyPair(settings.KeySize, settings.Format)
+                : CryptographicUtils.GenerateRsaKeyPair(
+                    settings.KeySize,
+                    settings.Format,
+                    passphrase
+                );
 
             // Write keys to files
             fileSystem.File.WriteAllText(privateKeyPath, keyPair.privateKey);
@@ -122,9 +201,26 @@ public sealed class GenerateCommand(IConsoleWriter writer, IFileSystem fileSyste
             writer.Info($"[red]Private Key:[/] {privateKeyPath}");
             writer.Info($"[yellow]Public Key:[/] {publicKeyPath}");
             writer.BlankLine();
-            writer.Warning($"[yellow]⚠️  Keep your private key secure and never share it![/]");
+            if (passphrase is null)
+            {
+                writer.Warning(
+                    $"[yellow]⚠️  The private key is NOT passphrase-protected. Keep it secure and never share it![/]"
+                );
+            }
+            else
+            {
+                writer.Info(
+                    $"[green]The private key is passphrase-encrypted (PKCS#8).[/] [yellow]There is no recovery if the passphrase is lost.[/]"
+                );
+                writer.Warning($"[yellow]⚠️  Keep your private key secure and never share it![/]");
+            }
 
             return ExitCodes.Success;
+        }
+        catch (PassphraseResolutionException ex)
+        {
+            writer.Error($"[red]✗ {ex.Message}[/]");
+            return ExitCodes.UsageError;
         }
         catch (IOException ex)
         {

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GenerateCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/GenerateCommand.cs
@@ -16,11 +16,13 @@ namespace Serilog.Sinks.File.Encrypt.Cli.Commands;
 /// <param name="writer">The verbosity-aware console writer.</param>
 /// <param name="fileSystem">The file system.</param>
 /// <param name="passphraseResolver">Resolves the private-key passphrase from file, environment, or prompt.</param>
+/// <param name="keyFileWriter">Writes key files, restricting the private key to the current user.</param>
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
 public sealed class GenerateCommand(
     IConsoleWriter writer,
     IFileSystem fileSystem,
-    IPassphraseResolver passphraseResolver
+    IPassphraseResolver passphraseResolver,
+    IKeyFileWriter keyFileWriter
 ) : Command<GenerateCommand.Settings>
 {
     /// <summary>
@@ -191,9 +193,9 @@ public sealed class GenerateCommand(
                     passphrase
                 );
 
-            // Write keys to files
-            fileSystem.File.WriteAllText(privateKeyPath, keyPair.privateKey);
-            fileSystem.File.WriteAllText(publicKeyPath, keyPair.publicKey);
+            // Write keys to files; the private key is restricted to the current user
+            keyFileWriter.WritePrivateKey(privateKeyPath, keyPair.privateKey);
+            keyFileWriter.WritePublicKey(publicKeyPath, keyPair.publicKey);
 
             // Output success message
             writer.Info($"[green]✓ Successfully generated RSA key pair![/]");

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
@@ -36,10 +36,15 @@ public static class CommandAppConfiguration
         {
             c.SetApplicationName("serilog-encrypt");
             c.AddCommand<GenerateCommand>(Generate)
-                .WithDescription("Generate a new RSA key pair for log encryption")
+                .WithDescription(
+                    "Generate a new RSA key pair for log encryption. The private key is "
+                        + "passphrase-encrypted (PKCS#8 PEM) unless --plaintext is passed."
+                )
                 .WithExample(Generate, "--output", "./keys")
-                .WithExample(Generate, "-o", "./keys", "-k", "4096")
-                .WithExample(Generate, "-o", "./keys", "-f", "Pem")
+                .WithExample(Generate, "-o", "./keys", "--key-size", "4096")
+                .WithExample(Generate, "-o", "./keys", "--passphrase-env", "MY_PASSPHRASE")
+                .WithExample(Generate, "-o", "./keys", "--passphrase-file", "passphrase.txt")
+                .WithExample(Generate, "-o", "./keys", "-f", "Xml", "--plaintext")
                 .WithExample(Generate, "-o", "./keys", "--force")
                 .WithExample(Generate, "-o", "./keys", "--quiet");
 

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
@@ -28,7 +28,7 @@ public static class CommandAppConfiguration
     /// <returns>An action that configures the CommandApp</returns>
     public static Action<IConfigurator> GetConfiguration()
     {
-        const string PrivateKey = "private_key.xml";
+        const string PrivateKey = "private_key.pem";
         const string Decrypt = "decrypt";
         const string Generate = "generate";
 
@@ -52,7 +52,7 @@ public static class CommandAppConfiguration
                 .WithDescription(
                     "Decrypt encrypted log files using an RSA private key. "
                         + "Exit codes: 0 success, 1 runtime failure, 2 usage error or refused overwrite, "
-                        + "3 no files matched, 4 nothing decrypted."
+                        + "3 no files matched, 4 nothing decrypted, 5 --require-sealed not met."
                 )
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey)
                 .WithExample(Decrypt, "*.log", "-k", PrivateKey)
@@ -60,6 +60,16 @@ public static class CommandAppConfiguration
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "-o", "decrypted.log")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--strict")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--force")
+                .WithExample(
+                    Decrypt,
+                    "app.log",
+                    "-k",
+                    PrivateKey,
+                    "--passphrase-env",
+                    "MY_PASSPHRASE"
+                )
+                .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--json")
+                .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--require-sealed")
                 .WithExample(Decrypt, "app.log", "-k", PrivateKey, "--verbose")
                 .WithExample(Decrypt, "./logs/*.log", "-k", PrivateKey, "--audit-log", "audit.log");
             c.ValidateExamples();

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton(AnsiConsole.Console);
         services.TryAddSingleton<IConsoleWriter, ConsoleWriter>();
         services.TryAddSingleton<IPassphraseResolver, PassphraseResolver>();
+        services.TryAddSingleton<IKeyFileWriter, KeyFileWriter>();
+        services.TryAddSingleton<IDecryptReporter, DecryptReporter>();
         return services;
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<IOutputResolver, OutputResolver>();
         services.TryAddSingleton(AnsiConsole.Console);
         services.TryAddSingleton<IConsoleWriter, ConsoleWriter>();
+        services.TryAddSingleton<IPassphraseResolver, PassphraseResolver>();
         return services;
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/ConsoleWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/ConsoleWriter.cs
@@ -1,14 +1,42 @@
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Serilog.Sinks.File.Encrypt.Cli;
 
 /// <summary>
 /// Default <see cref="IConsoleWriter"/> writing Spectre.Console markup to the injected
-/// console.
+/// console, with an optional error channel for --json runs.
 /// </summary>
-/// <param name="console">The ANSI console to write to.</param>
-public sealed class ConsoleWriter(IAnsiConsole console) : IConsoleWriter
+public sealed class ConsoleWriter : IConsoleWriter
 {
+    private readonly IAnsiConsole _stdout;
+    private IAnsiConsole _target;
+
+    /// <summary>
+    /// Creates a writer over the console bound to standard output.
+    /// </summary>
+    /// <param name="console">The ANSI console bound to standard output.</param>
+    public ConsoleWriter(IAnsiConsole console)
+    {
+        _stdout = console;
+        _target = console;
+    }
+
+    /// <summary>
+    /// Creates the console used by <see cref="UseErrorChannel"/>. Defaults to a console
+    /// over stderr; tests replace it with a capturing console.
+    /// </summary>
+    public Func<IAnsiConsole> ErrorConsoleFactory { get; set; } =
+        () =>
+            AnsiConsole.Create(
+                new AnsiConsoleSettings
+                {
+                    Ansi = AnsiSupport.Detect,
+                    Interactive = InteractionSupport.No,
+                    Out = new AnsiConsoleOutput(Console.Error),
+                }
+            );
+
     /// <inheritdoc />
     public Verbosity Verbosity { get; set; } = Verbosity.Normal;
 
@@ -17,7 +45,7 @@ public sealed class ConsoleWriter(IAnsiConsole console) : IConsoleWriter
     {
         if (Verbosity != Verbosity.Quiet)
         {
-            console.MarkupLineInterpolated(markup);
+            _target.MarkupLineInterpolated(markup);
         }
     }
 
@@ -26,20 +54,20 @@ public sealed class ConsoleWriter(IAnsiConsole console) : IConsoleWriter
     {
         if (Verbosity == Verbosity.Verbose)
         {
-            console.MarkupLineInterpolated(markup);
+            _target.MarkupLineInterpolated(markup);
         }
     }
 
     /// <inheritdoc />
     public void Warning(FormattableString markup)
     {
-        console.MarkupLineInterpolated(markup);
+        _target.MarkupLineInterpolated(markup);
     }
 
     /// <inheritdoc />
     public void Error(FormattableString markup)
     {
-        console.MarkupLineInterpolated(markup);
+        _target.MarkupLineInterpolated(markup);
     }
 
     /// <inheritdoc />
@@ -47,7 +75,31 @@ public sealed class ConsoleWriter(IAnsiConsole console) : IConsoleWriter
     {
         if (Verbosity != Verbosity.Quiet)
         {
-            console.WriteLine();
+            _target.WriteLine();
         }
+    }
+
+    /// <inheritdoc />
+    public void Info(IRenderable renderable)
+    {
+        if (Verbosity != Verbosity.Quiet)
+        {
+            _target.Write(renderable);
+        }
+    }
+
+    /// <inheritdoc />
+    public void UseErrorChannel()
+    {
+        _target = ErrorConsoleFactory();
+    }
+
+    /// <inheritdoc />
+    public void Raw(string text)
+    {
+        // Straight to the stdout writer: bypasses markup parsing and width-based wrapping,
+        // which would otherwise be able to split JSON string literals.
+        _stdout.Profile.Out.Writer.Write(text);
+        _stdout.Profile.Out.Writer.Flush();
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReportModels.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReportModels.cs
@@ -1,0 +1,101 @@
+using System.Text.Json.Serialization;
+
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <summary>
+/// The outcome category of a single input file in a decrypt run. Serialized as camelCase
+/// strings in --json output.
+/// </summary>
+public enum FileOutcome
+{
+    /// <summary>The file decrypted (possibly with partial failures reported in the counts).</summary>
+    Success,
+
+    /// <summary>A runtime error (IO/crypto) failed the file.</summary>
+    Failed,
+
+    /// <summary>The file was refused: existing output without --force, or a path containment violation.</summary>
+    Refused,
+
+    /// <summary>Zero sessions and zero messages were decrypted (wrong key / not an encrypted log).</summary>
+    NothingDecrypted,
+}
+
+/// <summary>
+/// Per-session detail for the decrypt report, mirroring
+/// <c>Serilog.Sinks.File.Decrypt.Models.SessionResult</c>.
+/// </summary>
+public sealed record SessionReport(
+    int Index,
+    int FormatVersion,
+    string KeyId,
+    string SealStatus,
+    ulong? DeclaredFrameCount,
+    int DecryptedMessages,
+    int FailedMessages
+);
+
+/// <summary>
+/// Per-file result of a decrypt run.
+/// </summary>
+public sealed record FileReport(
+    string Input,
+    string? Output,
+    FileOutcome Outcome,
+    int DecryptedSessions,
+    int DecryptedMessages,
+    int FailedHeaders,
+    int FailedMessages,
+    int ResyncAttempts,
+    bool AllSessionsSealed,
+    IReadOnlyList<SessionReport> Sessions,
+    string? Error
+);
+
+/// <summary>
+/// Aggregated counts for a decrypt run. <paramref name="AllSessionsSealed"/> is strict:
+/// every session of every successful file is cryptographically verified as sealed — v1
+/// sessions (seal <c>NotApplicable</c>) count as NOT sealed, matching the library's
+/// <c>RequireSealed</c> semantics. Per-file <see cref="FileReport.AllSessionsSealed"/>
+/// keeps the library's v1-tolerant meaning.
+/// </summary>
+public sealed record RunSummary(
+    int Files,
+    int Succeeded,
+    int Failed,
+    int Refused,
+    int NothingDecrypted,
+    int TotalMessages,
+    int TotalResyncAttempts,
+    bool AllSessionsSealed
+);
+
+/// <summary>
+/// The complete machine-readable decrypt report emitted by <c>decrypt --json</c>.
+/// <see cref="SchemaVersion"/> is incremented on breaking schema changes.
+/// </summary>
+public sealed record DecryptRunReport(
+    int SchemaVersion,
+    IReadOnlyList<FileReport> Files,
+    RunSummary Summary,
+    int ExitCode
+)
+{
+    /// <summary>
+    /// The current --json schema version.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+}
+
+/// <summary>
+/// Source-generated JSON context for the --json report (camelCase, indented,
+/// enums as camelCase strings, nulls omitted).
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true
+)]
+[JsonSerializable(typeof(DecryptRunReport))]
+public sealed partial class DecryptReportJsonContext : JsonSerializerContext;

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReporter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReporter.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using Spectre.Console;
+
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <inheritdoc />
+public sealed class DecryptReporter(IConsoleWriter writer) : IDecryptReporter
+{
+    /// <inheritdoc />
+    public void ReportSessions(FileReport report)
+    {
+        if (report.Sessions.Count == 0)
+        {
+            return;
+        }
+
+        Table table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("Session")
+            .AddColumn("Version")
+            .AddColumn("KeyId")
+            .AddColumn("Messages")
+            .AddColumn("Failed")
+            .AddColumn("Seal");
+
+        foreach (SessionReport session in report.Sessions)
+        {
+            table.AddRow(
+                session.Index.ToString(),
+                $"v{session.FormatVersion}",
+                Markup.Escape(session.KeyId),
+                session.DecryptedMessages.ToString(),
+                session.FailedMessages.ToString(),
+                FormatSeal(session)
+            );
+        }
+
+        writer.Info(table);
+    }
+
+    /// <inheritdoc />
+    public void ReportSummary(RunSummary summary)
+    {
+        Table table = new Table()
+            .Border(TableBorder.Rounded)
+            .Title("[bold]Summary[/]")
+            .AddColumn("Files")
+            .AddColumn("Succeeded")
+            .AddColumn("Failed")
+            .AddColumn("Refused")
+            .AddColumn("Nothing decrypted")
+            .AddColumn("Messages")
+            .AddColumn("Resyncs");
+
+        table.AddRow(
+            summary.Files.ToString(),
+            $"[green]{summary.Succeeded}[/]",
+            summary.Failed > 0 ? $"[red]{summary.Failed}[/]" : "0",
+            summary.Refused > 0 ? $"[yellow]{summary.Refused}[/]" : "0",
+            summary.NothingDecrypted > 0 ? $"[yellow]{summary.NothingDecrypted}[/]" : "0",
+            summary.TotalMessages.ToString(),
+            summary.TotalResyncAttempts.ToString()
+        );
+
+        writer.Info(table);
+
+        if (summary.Failed > 0)
+        {
+            writer.Warning($"  [red]✗ Failed:[/] {summary.Failed}");
+        }
+        if (summary.Refused > 0)
+        {
+            writer.Warning($"  [yellow]⚠ Refused:[/] {summary.Refused}");
+        }
+        if (summary.NothingDecrypted > 0)
+        {
+            writer.Warning($"  [yellow]⚠ Nothing decrypted:[/] {summary.NothingDecrypted}");
+        }
+    }
+
+    /// <inheritdoc />
+    public string ToJson(DecryptRunReport report)
+    {
+        return JsonSerializer.Serialize(report, DecryptReportJsonContext.Default.DecryptRunReport);
+    }
+
+    private static string FormatSeal(SessionReport session) =>
+        session.SealStatus switch
+        {
+            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.Sealed) => "[green]Sealed[/]",
+            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.NotApplicable) =>
+                "[dim]v1 (n/a)[/]",
+            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.Unsealed) => "[yellow]Unsealed[/]",
+            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.SealCountMismatch) =>
+                $"[red]Count mismatch (declared {session.DeclaredFrameCount})[/]",
+            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.SealInvalid) => "[red]Invalid[/]",
+            _ => Markup.Escape(session.SealStatus),
+        };
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/IConsoleWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/IConsoleWriter.cs
@@ -58,4 +58,24 @@ public interface IConsoleWriter
     /// Writes a blank spacer line. Dropped when <see cref="Verbosity"/> is Quiet.
     /// </summary>
     void BlankLine();
+
+    /// <summary>
+    /// Writes a renderable (e.g. a table) at informational level. Dropped when
+    /// <see cref="Verbosity"/> is Quiet.
+    /// </summary>
+    /// <param name="renderable">The renderable to write.</param>
+    void Info(Spectre.Console.Rendering.IRenderable renderable);
+
+    /// <summary>
+    /// Routes all subsequent human output (Info/Verbose/Warning/Error/BlankLine) to the
+    /// error channel, keeping standard output clean for machine-readable data (--json).
+    /// </summary>
+    void UseErrorChannel();
+
+    /// <summary>
+    /// Writes raw text to standard output — no markup interpretation, no line wrapping,
+    /// unaffected by verbosity or <see cref="UseErrorChannel"/>. Used for --json payloads.
+    /// </summary>
+    /// <param name="text">The exact text to write.</param>
+    void Raw(string text);
 }

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/IDecryptReporter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/IDecryptReporter.cs
@@ -1,0 +1,27 @@
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <summary>
+/// Renders decrypt-run results: a per-file session table and a run summary table for
+/// humans, and the versioned JSON payload for --json.
+/// </summary>
+public interface IDecryptReporter
+{
+    /// <summary>
+    /// Writes the per-file session table (informational level).
+    /// </summary>
+    /// <param name="report">The file report to render.</param>
+    void ReportSessions(FileReport report);
+
+    /// <summary>
+    /// Writes the run summary table and its warning lines.
+    /// </summary>
+    /// <param name="summary">The run summary to render.</param>
+    void ReportSummary(RunSummary summary);
+
+    /// <summary>
+    /// Serializes the full run report to indented JSON (schemaVersion included).
+    /// </summary>
+    /// <param name="report">The run report to serialize.</param>
+    /// <returns>The JSON text.</returns>
+    string ToJson(DecryptRunReport report);
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/IKeyFileWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/IKeyFileWriter.cs
@@ -1,0 +1,24 @@
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <summary>
+/// Writes generated key files to disk, restricting private key files to owner-only access
+/// (mode 600 on Unix, an owner-only DACL on Windows). Public keys are written with default
+/// permissions. Failure to restrict permissions is reported as a warning, never a failure —
+/// the key material itself is still written.
+/// </summary>
+public interface IKeyFileWriter
+{
+    /// <summary>
+    /// Writes the private key and restricts the file to the current user.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    /// <param name="contents">The private key text.</param>
+    void WritePrivateKey(string path, string contents);
+
+    /// <summary>
+    /// Writes the public key with default permissions.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    /// <param name="contents">The public key text.</param>
+    void WritePublicKey(string path, string contents);
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/IPassphraseResolver.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/IPassphraseResolver.cs
@@ -1,0 +1,42 @@
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <summary>
+/// Thrown when a passphrase source was specified but could not produce a usable passphrase
+/// (missing file, unset environment variable, mismatched confirmation, ...). Commands map
+/// this to the usage-error exit code.
+/// </summary>
+public sealed class PassphraseResolutionException(string message) : Exception(message);
+
+/// <summary>
+/// Resolves the private-key passphrase from the supported sources, in order:
+/// <c>--passphrase-file</c> (first line of the file), <c>--passphrase-env</c> (named
+/// environment variable), the <c>SERILOG_ENCRYPT_PASSPHRASE</c> environment variable, and
+/// finally an interactive hidden prompt when the console supports it. There is deliberately
+/// no command-line passphrase option — secrets on argv leak via shell history and process
+/// listings.
+/// </summary>
+public interface IPassphraseResolver
+{
+    /// <summary>
+    /// The name of the environment variable that is always checked as a fallback source.
+    /// </summary>
+    const string DefaultEnvironmentVariable = "SERILOG_ENCRYPT_PASSPHRASE";
+
+    /// <summary>
+    /// Resolves a passphrase from the configured sources.
+    /// </summary>
+    /// <param name="passphraseFile">Path of a file whose first line is the passphrase, or null.</param>
+    /// <param name="passphraseEnv">Name of an environment variable holding the passphrase, or null.</param>
+    /// <param name="confirm">
+    /// When prompting interactively, ask for the passphrase twice and require both entries
+    /// to match (used when creating a new key).
+    /// </param>
+    /// <returns>
+    /// The resolved passphrase, or null when no source is configured and the console is
+    /// not interactive — the caller decides whether that is an error.
+    /// </returns>
+    /// <exception cref="PassphraseResolutionException">
+    /// A configured source could not produce a non-empty passphrase.
+    /// </exception>
+    string? Resolve(string? passphraseFile, string? passphraseEnv, bool confirm);
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/KeyFileWriter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/KeyFileWriter.cs
@@ -1,0 +1,114 @@
+using System.IO.Abstractions;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <inheritdoc />
+public sealed class KeyFileWriter(IFileSystem fileSystem, IConsoleWriter writer) : IKeyFileWriter
+{
+    private const UnixFileMode OwnerOnly = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    /// <inheritdoc />
+    public void WritePrivateKey(string path, string contents)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            fileSystem.File.WriteAllText(path, contents);
+            RestrictOnWindows(path);
+            return;
+        }
+
+        // Unix: create with owner-only mode so there is no window where the file is
+        // readable by others; SetUnixFileMode afterwards covers the overwrite case,
+        // where UnixCreateMode does not apply.
+        FileStreamOptions options = new()
+        {
+            Mode = FileMode.Create,
+            Access = FileAccess.Write,
+            Share = FileShare.None,
+            UnixCreateMode = OwnerOnly,
+        };
+        using (FileSystemStream stream = fileSystem.FileStream.New(path, options))
+        using (StreamWriter streamWriter = new(stream))
+        {
+            streamWriter.Write(contents);
+        }
+
+        try
+        {
+            fileSystem.File.SetUnixFileMode(path, OwnerOnly);
+            writer.Verbose($"  [dim]{path}: permissions restricted to owner (600)[/]");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            writer.Warning(
+                $"[yellow]⚠ Could not restrict permissions on {path}: {ex.Message}. Restrict access manually.[/]"
+            );
+        }
+    }
+
+    /// <inheritdoc />
+    public void WritePublicKey(string path, string contents)
+    {
+        fileSystem.File.WriteAllText(path, contents);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private void RestrictOnWindows(string path)
+    {
+        // ACLs are not exposed through System.IO.Abstractions, so this uses System.IO
+        // directly — but only against the real file system; with a mock (tests) the
+        // restriction is skipped.
+        if (fileSystem is not FileSystem)
+        {
+            return;
+        }
+
+        try
+        {
+            RestrictAclToCurrentUser(path);
+            writer.Verbose($"  [dim]{path}: ACL restricted to the current user[/]");
+        }
+        catch (Exception ex)
+            when (ex
+                    is IOException
+                        or UnauthorizedAccessException
+                        or PlatformNotSupportedException
+                        or InvalidOperationException
+            )
+        {
+            writer.Warning(
+                $"[yellow]⚠ Could not restrict permissions on {path}: {ex.Message}. Restrict access manually.[/]"
+            );
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RestrictAclToCurrentUser(string path)
+    {
+        SecurityIdentifier? user = WindowsIdentity.GetCurrent().User;
+        if (user is null)
+        {
+            throw new InvalidOperationException("Could not determine the current Windows user.");
+        }
+
+        FileInfo fileInfo = new(path);
+        FileSecurity security = fileInfo.GetAccessControl();
+        security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        foreach (
+            FileSystemAccessRule rule in security
+                .GetAccessRules(true, true, typeof(SecurityIdentifier))
+                .Cast<FileSystemAccessRule>()
+        )
+        {
+            security.RemoveAccessRule(rule);
+        }
+
+        security.AddAccessRule(
+            new FileSystemAccessRule(user, FileSystemRights.FullControl, AccessControlType.Allow)
+        );
+        fileInfo.SetAccessControl(security);
+    }
+}

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/PassphraseResolver.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/PassphraseResolver.cs
@@ -1,0 +1,91 @@
+using System.IO.Abstractions;
+using Spectre.Console;
+
+namespace Serilog.Sinks.File.Encrypt.Cli;
+
+/// <inheritdoc />
+public sealed class PassphraseResolver(IAnsiConsole console, IFileSystem fileSystem)
+    : IPassphraseResolver
+{
+    /// <inheritdoc />
+    public string? Resolve(string? passphraseFile, string? passphraseEnv, bool confirm)
+    {
+        if (!string.IsNullOrWhiteSpace(passphraseFile))
+        {
+            return FromFile(passphraseFile);
+        }
+
+        if (!string.IsNullOrWhiteSpace(passphraseEnv))
+        {
+            return FromEnvironment(passphraseEnv);
+        }
+
+        string? fallback = Environment.GetEnvironmentVariable(
+            IPassphraseResolver.DefaultEnvironmentVariable
+        );
+        if (!string.IsNullOrEmpty(fallback))
+        {
+            return fallback;
+        }
+
+        if (console.Profile.Capabilities.Interactive)
+        {
+            return FromPrompt(confirm);
+        }
+
+        return null;
+    }
+
+    private string FromFile(string path)
+    {
+        if (!fileSystem.File.Exists(path))
+        {
+            throw new PassphraseResolutionException($"Passphrase file '{path}' does not exist.");
+        }
+
+        string? firstLine = fileSystem.File.ReadLines(path).FirstOrDefault();
+        if (string.IsNullOrEmpty(firstLine))
+        {
+            throw new PassphraseResolutionException(
+                $"Passphrase file '{path}' is empty; the first line must contain the passphrase."
+            );
+        }
+
+        return firstLine;
+    }
+
+    private static string FromEnvironment(string variableName)
+    {
+        string? value = Environment.GetEnvironmentVariable(variableName);
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new PassphraseResolutionException(
+                $"Environment variable '{variableName}' is not set or empty."
+            );
+        }
+
+        return value;
+    }
+
+    private string FromPrompt(bool confirm)
+    {
+        string passphrase = console.Prompt(new TextPrompt<string>("Enter passphrase:").Secret());
+        if (string.IsNullOrEmpty(passphrase))
+        {
+            throw new PassphraseResolutionException("Passphrase must not be empty.");
+        }
+
+        if (confirm)
+        {
+            string confirmation = console.Prompt(
+                new TextPrompt<string>("Confirm passphrase:").Secret()
+            );
+            if (!string.Equals(passphrase, confirmation, StringComparison.Ordinal))
+            {
+                throw new PassphraseResolutionException("Passphrases do not match.");
+            }
+        }
+
+        return passphrase;
+    }
+}

--- a/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
@@ -33,16 +33,34 @@ public static class CryptographicUtils
     public static readonly byte[] MagicBytes = [0xFF, 0x42, 0x32, 0x50, 0xFF, 0xDA, 0x7E, 0x00];
 
     /// <summary>
+    /// Returns true when the given key string is a passphrase-encrypted PKCS#8 PEM
+    /// (an <c>ENCRYPTED PRIVATE KEY</c> block), which requires a passphrase to import.
+    /// </summary>
+    /// <param name="key">The RSA key as a string.</param>
+    public static bool IsEncryptedPem(string key) =>
+        key is not null && key.Contains("ENCRYPTED PRIVATE KEY", StringComparison.Ordinal);
+
+    /// <summary>
     /// Imports an RSA key into an <see cref="RSA"/> instance from a string in either XML or PEM format.
     /// </summary>
     /// <param name="rsa">The <see cref="RSA"/> instance to import the key into.</param>
     /// <param name="key">The RSA key as a string.</param>
-    /// <exception cref="CryptographicException">Unknown or invalid key format.</exception>
+    /// <exception cref="CryptographicException">
+    /// Unknown or invalid key format, or the key is passphrase-encrypted (use the
+    /// passphrase overload).
+    /// </exception>
     /// <exception cref="ArgumentException">Thrown if the key is empty.</exception>
     /// <exception cref="ArgumentNullException">Thrown if the key is null.</exception>
     public static void FromString(this RSA rsa, string key)
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
+
+        if (IsEncryptedPem(key))
+        {
+            throw new CryptographicException(
+                "The RSA private key is passphrase-encrypted; a passphrase is required to import it."
+            );
+        }
 
         try
         {
@@ -59,6 +77,52 @@ public static class CryptographicUtils
                         "Invalid RSA key format. Key must be in XML or PEM format."
                     );
             }
+        }
+        catch (Exception ex)
+            when (ex is FormatException or ArgumentException or ArgumentNullException)
+        {
+            throw new CryptographicException(
+                "Failed to import RSA key. See inner exception for details.",
+                ex
+            );
+        }
+    }
+
+    /// <summary>
+    /// Imports an RSA key into an <see cref="RSA"/> instance from a string, additionally
+    /// supporting passphrase-encrypted PKCS#8 PEM keys (<c>ENCRYPTED PRIVATE KEY</c> blocks,
+    /// as produced by <see cref="GenerateRsaKeyPair(int, KeyFormat, ReadOnlySpan{char})"/>).
+    /// Unencrypted XML/PEM keys import as usual and the passphrase is ignored.
+    /// </summary>
+    /// <param name="rsa">The <see cref="RSA"/> instance to import the key into.</param>
+    /// <param name="key">The RSA key as a string.</param>
+    /// <param name="passphrase">The passphrase for an encrypted key; may be empty for unencrypted keys.</param>
+    /// <exception cref="CryptographicException">
+    /// Unknown or invalid key format, a missing passphrase for an encrypted key, or a wrong
+    /// passphrase.
+    /// </exception>
+    /// <exception cref="ArgumentException">Thrown if the key is empty.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the key is null.</exception>
+    public static void FromString(this RSA rsa, string key, ReadOnlySpan<char> passphrase)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        if (!IsEncryptedPem(key))
+        {
+            rsa.FromString(key);
+            return;
+        }
+
+        if (passphrase.IsEmpty)
+        {
+            throw new CryptographicException(
+                "The RSA private key is passphrase-encrypted; a passphrase is required to import it."
+            );
+        }
+
+        try
+        {
+            rsa.ImportFromEncryptedPem(key, passphrase);
         }
         catch (Exception ex)
             when (ex is FormatException or ArgumentException or ArgumentNullException)

--- a/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Core/CryptographicUtils.cs
@@ -128,8 +128,8 @@ public static class CryptographicUtils
     /// <summary>
     /// Generates a new RSA key pair for encryption and decryption operations.
     /// </summary>
-    /// <param name="keySize">The size of the key in bits. Must be at least 2048. Recommended: 2048 (default) or 4096 for enhanced security.</param>
-    /// <param name="format">The format in which to export the keys. Default is XML.</param>
+    /// <param name="keySize">The size of the key in bits. Must be at least 2048. Recommended: 3072 or 4096 for enhanced security.</param>
+    /// <param name="format">The format in which to export the keys. Default is PEM.</param>
     /// <returns>A tuple containing the public and private keys in XML or PEM format. The public key should be distributed to log producers, while the private key must be kept secure.</returns>
     /// <exception cref="NotSupportedException">Thrown when the key format is not supported.</exception>
     /// <exception cref="CryptographicException">Thrown when key generation fails, or when <paramref name="keySize"/> is less than the 2048-bit minimum.</exception>
@@ -137,41 +137,33 @@ public static class CryptographicUtils
     /// <para>
     /// <b>Key Size Recommendations:</b>
     /// - 2048-bit: Standard security, faster encryption/decryption, smaller encrypted headers (default)
-    /// - 4096-bit: Enhanced security, slower operations, larger encrypted headers (recommended for highly sensitive data)
+    /// - 3072/4096-bit: Enhanced security, slower operations, larger encrypted headers (recommended for highly sensitive data)
     /// </para>
     /// <para>
     /// <b>Key Storage:</b> Store private keys securely using Azure Key Vault, AWS Secrets Manager, or encrypted configuration.
-    /// Never commit private keys to source control.
+    /// Never commit private keys to source control. Prefer the passphrase-protected overload
+    /// for private keys that must live on disk.
     /// </para>
     /// </remarks>
     /// <example>
     /// <code>
-    /// // Generate 2048-bit key pair (default)
+    /// // Generate 2048-bit PEM key pair (default)
     /// var (publicKey, privateKey) = CryptographicUtils.GenerateRsaKeyPair();
     ///
     /// // Generate 4096-bit key pair for enhanced security
     /// var (publicKey4k, privateKey4k) = CryptographicUtils.GenerateRsaKeyPair(4096);
     ///
     /// // Store keys securely
-    /// File.WriteAllText("public_key.xml", publicKey);
+    /// File.WriteAllText("public_key.pem", publicKey);
     /// // Use secure storage for private key (Azure Key Vault, etc.)
     /// </code>
     /// </example>
     public static (string publicKey, string privateKey) GenerateRsaKeyPair(
         int keySize = 2048,
-        KeyFormat format = KeyFormat.Xml
+        KeyFormat format = KeyFormat.Pem
     )
     {
-        // Enforce the documented minimum up front. RSA.Create would happily create a weak
-        // (e.g. 1024-bit) key otherwise, contradicting the contract and MinimumRsaKeySize.
-        if (keySize < EncryptionConstants.MinimumRsaKeySize)
-        {
-            throw new CryptographicException(
-                $"RSA key size must be at least {EncryptionConstants.MinimumRsaKeySize} bits, but was {keySize}."
-            );
-        }
-
-        using RSA rsa = RSA.Create(keySize);
+        using RSA rsa = CreateValidatedRsa(keySize);
 
         (string publicKey, string privateKey) = format switch
         {
@@ -184,5 +176,78 @@ public static class CryptographicUtils
         };
 
         return (publicKey, privateKey);
+    }
+
+    /// <summary>
+    /// Generates a new RSA key pair whose private key is encrypted with the given
+    /// passphrase as a PKCS#8 <c>ENCRYPTED PRIVATE KEY</c> PEM block
+    /// (PBKDF2-SHA256, 600,000 iterations, AES-256-CBC). The public key is a regular
+    /// (unencrypted) PEM block. Only <see cref="KeyFormat.Pem"/> supports encryption —
+    /// the legacy XML format has no encrypted representation.
+    /// </summary>
+    /// <param name="keySize">The size of the key in bits. Must be at least 2048.</param>
+    /// <param name="format">The export format; must be <see cref="KeyFormat.Pem"/>.</param>
+    /// <param name="passphrase">The passphrase protecting the private key. Must not be empty.</param>
+    /// <returns>A tuple of the plaintext public key PEM and the encrypted private key PEM.</returns>
+    /// <exception cref="NotSupportedException">Thrown for <see cref="KeyFormat.Xml"/> or an unknown format.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="passphrase"/> is empty.</exception>
+    /// <exception cref="CryptographicException">Thrown when key generation fails, or when <paramref name="keySize"/> is less than the 2048-bit minimum.</exception>
+    /// <example>
+    /// <code>
+    /// var (publicKey, encryptedPrivateKey) =
+    ///     CryptographicUtils.GenerateRsaKeyPair(3072, KeyFormat.Pem, "correct horse battery staple");
+    ///
+    /// // Later, import with the passphrase:
+    /// using var rsa = RSA.Create();
+    /// rsa.ImportFromEncryptedPem(encryptedPrivateKey, "correct horse battery staple");
+    /// </code>
+    /// </example>
+    public static (string publicKey, string privateKey) GenerateRsaKeyPair(
+        int keySize,
+        KeyFormat format,
+        ReadOnlySpan<char> passphrase
+    )
+    {
+        if (format != KeyFormat.Pem)
+        {
+            throw new NotSupportedException(
+                $"Passphrase-encrypted private keys require the Pem format; '{format}' has no encrypted representation."
+            );
+        }
+
+        if (passphrase.IsEmpty)
+        {
+            throw new ArgumentException(
+                "Passphrase must not be empty. Use the overload without a passphrase for an unencrypted key.",
+                nameof(passphrase)
+            );
+        }
+
+        using RSA rsa = CreateValidatedRsa(keySize);
+
+        PbeParameters pbe = new(
+            PbeEncryptionAlgorithm.Aes256Cbc,
+            HashAlgorithmName.SHA256,
+            iterationCount: 600_000
+        );
+
+        return (
+            rsa.ExportRSAPublicKeyPem(),
+            rsa.ExportEncryptedPkcs8PrivateKeyPem(passphrase, pbe)
+        );
+    }
+
+    private static RSA CreateValidatedRsa(int keySize)
+    {
+        // Enforce the documented minimum up front. RSA.Create would happily create a weak
+        // (e.g. 1024-bit) key otherwise, contradicting the contract and MinimumRsaKeySize.
+        if (keySize < EncryptionConstants.MinimumRsaKeySize)
+        {
+            throw new CryptographicException(
+                $"RSA key size must be at least {EncryptionConstants.MinimumRsaKeySize} bits, but was {keySize}."
+            );
+        }
+
+        return RSA.Create(keySize);
     }
 }

--- a/src/Serilog.Sinks.File.Encrypt/EncryptHooks.cs
+++ b/src/Serilog.Sinks.File.Encrypt/EncryptHooks.cs
@@ -48,7 +48,7 @@ public class EncryptHooks : FileLifecycleHooks
     /// <summary>
     /// Creates a new instance of <see cref="EncryptHooks"/> with the provided RSA public key.
     /// </summary>
-    /// <param name="publicKey">The RSA public key in XML or PEM format. Use <see cref="CryptographicUtils.GenerateRsaKeyPair"/> to generate keys.</param>
+    /// <param name="publicKey">The RSA public key in XML or PEM format. Use <see cref="CryptographicUtils.GenerateRsaKeyPair(int, KeyFormat)"/> to generate keys.</param>
     /// <param name="keyId">Optional key ID to include in the header for key rotation. Default is an empty string. Max 32 bytes.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="publicKey"/> or <paramref name="keyId"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="publicKey"/> is empty or whitespace, or when <paramref name="keyId"/> exceeds 32 bytes when UTF-8 encoded.</exception>

--- a/tests/Serilog.Sinks.File.Decrypt.Tests/LocalKeyProviderTests.cs
+++ b/tests/Serilog.Sinks.File.Decrypt.Tests/LocalKeyProviderTests.cs
@@ -11,6 +11,84 @@ public class LocalKeyProviderTests
     private static readonly (string PublicKey, string PrivateKey) _keyPair4096 =
         CryptographicUtils.GenerateRsaKeyPair(keySize: 4096, format: KeyFormat.Xml);
 
+    private static readonly (string PublicKey, string PrivateKey) _encryptedPemKeyPair =
+        CryptographicUtils.GenerateRsaKeyPair(2048, KeyFormat.Pem, "provider-passphrase");
+
+    #region Passphrase-encrypted keys
+
+    [Fact]
+    public void Constructor_EncryptedKeyWithCorrectPassphrase_CreatesInstance()
+    {
+        Should.NotThrow(() =>
+        {
+            using var provider = new LocalKeyProvider(
+                "key1",
+                _encryptedPemKeyPair.PrivateKey,
+                "provider-passphrase"
+            );
+        });
+    }
+
+    [Fact]
+    public void Constructor_EncryptedKeyWithWrongPassphrase_ThrowsCryptographicException()
+    {
+        Should.Throw<CryptographicException>(() =>
+            new LocalKeyProvider("key1", _encryptedPemKeyPair.PrivateKey, "wrong-passphrase")
+        );
+    }
+
+    [Fact]
+    public void Constructor_EncryptedKeyWithoutPassphrase_ThrowsCryptographicException()
+    {
+        Should
+            .Throw<CryptographicException>(() =>
+                new LocalKeyProvider("key1", _encryptedPemKeyPair.PrivateKey)
+            )
+            .Message.ShouldContain("passphrase");
+    }
+
+    [Fact]
+    public void Constructor_KeyMapWithEncryptedKeys_SharesPassphrase()
+    {
+        var keyMap = new Dictionary<string, string>
+        {
+            { "enc", _encryptedPemKeyPair.PrivateKey },
+            { "plain", _pemKeyPair.PrivateKey }, // unencrypted keys ignore the passphrase
+        };
+
+        Should.NotThrow(() =>
+        {
+            using var provider = new LocalKeyProvider(keyMap, "provider-passphrase");
+        });
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithEncryptedKey_DecryptsHeaderPayload()
+    {
+        // Arrange — RSA-encrypt a payload with the public key, decrypt via the provider
+        using var rsa = RSA.Create();
+        rsa.FromString(_encryptedPemKeyPair.PublicKey);
+        byte[] payload = [1, 2, 3, 4];
+        byte[] cipherText = rsa.Encrypt(payload, RSAEncryptionPadding.OaepSHA256);
+        using var provider = new LocalKeyProvider(
+            "",
+            _encryptedPemKeyPair.PrivateKey,
+            "provider-passphrase"
+        );
+
+        // Act
+        byte[] decrypted = await provider.DecryptAsync(
+            "",
+            cipherText,
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert
+        decrypted.ShouldBe(payload);
+    }
+
+    #endregion
+
     #region Constructor(Dictionary<string, string>)
 
     [Fact]

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/DecryptCommandTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/DecryptCommandTests.cs
@@ -8,6 +8,8 @@ public class DecryptCommandTests : CommandTestBase
 {
     private readonly IInputResolver _inputResolver = Substitute.For<IInputResolver>();
     private readonly IOutputResolver _outputResolver = Substitute.For<IOutputResolver>();
+    private readonly IPassphraseResolver _passphraseResolver =
+        Substitute.For<IPassphraseResolver>();
     private readonly string _publicKey;
     private readonly string _privateKey;
     private readonly string _privateKeyPath = Path.Join("keys", "private_key.xml");
@@ -334,7 +336,7 @@ public class DecryptCommandTests : CommandTestBase
         // Assert
         result.ShouldBe(1); // Failure due to one failed file
         TestConsole.Output.ShouldContain("Found 2 file(s) to decrypt");
-        TestConsole.Output.ShouldContain("✓ Success: 1");
+        TestConsole.Output.ShouldContain("Succeeded"); // summary table
         TestConsole.Output.ShouldContain("✗ Failed: 1");
     }
 
@@ -462,7 +464,7 @@ public class DecryptCommandTests : CommandTestBase
     }
 
     [Fact]
-    public async Task ExecuteAsync_UnsealedFile_RequireSealedWithoutStrict_StillSucceeds()
+    public async Task ExecuteAsync_UnsealedFile_RequireSealedWithoutStrict_ExitsNotSealed()
     {
         // Arrange
         string unsealedFile = Path.Join("logs", "crashed.log");
@@ -488,9 +490,11 @@ public class DecryptCommandTests : CommandTestBase
             CancellationToken.None
         );
 
-        // Assert: RequireSealed only becomes fatal together with --strict
-        result.ShouldBe(0);
+        // Assert: without --strict the file still decrypts and reports, but the run
+        // signals the unmet integrity requirement via exit code 5
+        result.ShouldBe(ExitCodes.NotSealed);
         TestConsole.Output.ShouldContain("UNSEALED");
+        TestConsole.Output.ShouldContain("--require-sealed");
     }
 
     [Fact]
@@ -726,6 +730,245 @@ public class DecryptCommandTests : CommandTestBase
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithEncryptedKeyAndPassphrase_DecryptsSuccessfully()
+    {
+        // Arrange — full round trip with a passphrase-encrypted private key
+        const string Passphrase = "round-trip-secret";
+        (string publicKey, string encryptedPrivateKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            Passphrase
+        );
+        string keyPath = Path.Join("keys", "encrypted_key.pem");
+        FileSystem.AddFile(keyPath, new MockFileData(encryptedPrivateKey));
+        FileSystem.AddFile(
+            "enc.log",
+            new MockFileData(CreateEncryptedLogFile(LogContent1, publicKey))
+        );
+        ConfigureFileResolver("enc.log");
+        _passphraseResolver
+            .Resolve(Arg.Any<string?>(), Arg.Any<string?>(), confirm: false)
+            .Returns(Passphrase);
+
+        string decryptedFilePath = Path.Join("logs", "enc-decrypted.log");
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new()
+        {
+            InputPath = "enc.log",
+            KeyFile = keyPath,
+            OutputPath = decryptedFilePath,
+        };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.Success);
+        (
+            await FileSystem.File.ReadAllTextAsync(
+                decryptedFilePath,
+                TestContext.Current.CancellationToken
+            )
+        ).ShouldBe(LogContent1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EncryptedKeyNoPassphraseSource_ExitsUsageError()
+    {
+        // Arrange
+        (_, string encryptedPrivateKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "some-passphrase"
+        );
+        string keyPath = Path.Join("keys", "encrypted_key.pem");
+        FileSystem.AddFile(keyPath, new MockFileData(encryptedPrivateKey));
+        _passphraseResolver
+            .Resolve(Arg.Any<string?>(), Arg.Any<string?>(), confirm: false)
+            .Returns((string?)null);
+
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new() { InputPath = EncryptedFile, KeyFile = keyPath };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.UsageError);
+        TestConsole.Output.ShouldContain("passphrase-encrypted");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EncryptedKeyWrongPassphrase_ExitsRuntimeFailure()
+    {
+        // Arrange
+        (_, string encryptedPrivateKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "right-passphrase"
+        );
+        string keyPath = Path.Join("keys", "encrypted_key.pem");
+        FileSystem.AddFile(keyPath, new MockFileData(encryptedPrivateKey));
+        _passphraseResolver
+            .Resolve(Arg.Any<string?>(), Arg.Any<string?>(), confirm: false)
+            .Returns("wrong-passphrase");
+
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new() { InputPath = EncryptedFile, KeyFile = keyPath };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert — clear failure, not silent success
+        result.ShouldBe(ExitCodes.RuntimeFailure);
+        TestConsole.Output.ShouldContain("✗ Decryption failed:");
+    }
+
+    [Fact]
+    public void Validate_DefaultKeyMissingButXmlExists_HintsAtOldDefault()
+    {
+        // Arrange — no private_key.pem, but a legacy private_key.xml is present
+        FileSystem.AddFile("private_key.xml", new MockFileData(_privateKey));
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new() { InputPath = EncryptedFile };
+
+        // Act
+        ValidationResult result = command.Validate(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings
+        );
+
+        // Assert
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldNotBeNull();
+        result.Message.ShouldContain("private_key.xml");
+        result.Message.ShouldContain("-k private_key.xml");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithJson_WritesOnlyJsonToStdoutAndHumanTextToStderr()
+    {
+        // Arrange — capture the error channel in a second console
+        using TestConsole stderrConsole = new();
+        Writer.ErrorConsoleFactory = () => stderrConsole;
+        string decryptedFilePath = Path.Join("logs", "decrypted.log");
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new()
+        {
+            InputPath = EncryptedFile,
+            KeyFile = _privateKeyPath,
+            OutputPath = decryptedFilePath,
+            Json = true,
+        };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert — stdout is pure JSON
+        result.ShouldBe(ExitCodes.Success);
+        string stdout = TestConsole.Output;
+        stdout.TrimStart().ShouldStartWith("{");
+        using System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse(stdout);
+        doc.RootElement.GetProperty("schemaVersion").GetInt32().ShouldBe(1);
+        doc.RootElement.GetProperty("exitCode").GetInt32().ShouldBe(0);
+        System.Text.Json.JsonElement files = doc.RootElement.GetProperty("files");
+        files.GetArrayLength().ShouldBe(1);
+        files[0].GetProperty("outcome").GetString().ShouldBe("Success");
+        files[0].GetProperty("decryptedMessages").GetInt32().ShouldBe(1);
+        files[0]
+            .GetProperty("sessions")[0]
+            .GetProperty("sealStatus")
+            .GetString()
+            .ShouldBe("Sealed");
+        doc.RootElement.GetProperty("summary").GetProperty("succeeded").GetInt32().ShouldBe(1);
+
+        // Human text went to the error channel
+        stderrConsole.Output.ShouldContain("✓ Decrypted:");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithJson_ZeroOutputFile_ReportsOutcomeAndExitCode()
+    {
+        // Arrange
+        using TestConsole stderrConsole = new();
+        Writer.ErrorConsoleFactory = () => stderrConsole;
+        FileSystem.AddFile("empty.log", new MockFileData(Array.Empty<byte>()));
+        ConfigureFileResolver("empty.log");
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new()
+        {
+            InputPath = "empty.log",
+            KeyFile = _privateKeyPath,
+            OutputPath = Path.Join("logs", "empty-decrypted.log"),
+            Json = true,
+        };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.NothingDecrypted);
+        using System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse(
+            TestConsole.Output
+        );
+        doc.RootElement.GetProperty("exitCode").GetInt32().ShouldBe(ExitCodes.NothingDecrypted);
+        doc.RootElement.GetProperty("files")[0]
+            .GetProperty("outcome")
+            .GetString()
+            .ShouldBe("NothingDecrypted");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SuccessfulDecrypt_ShowsSessionTable()
+    {
+        // Arrange
+        TestConsole.Profile.Width = 200;
+        string decryptedFilePath = Path.Join("logs", "decrypted.log");
+        DecryptCommand command = GetSut();
+        DecryptCommand.Settings settings = new()
+        {
+            InputPath = EncryptedFile,
+            KeyFile = _privateKeyPath,
+            OutputPath = decryptedFilePath,
+        };
+
+        // Act
+        int result = await command.ExecuteAsync(
+            new CommandContext(Arguments, Remaining, "decrypt", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert — per-file session table and run summary table are rendered
+        result.ShouldBe(ExitCodes.Success);
+        TestConsole.Output.ShouldContain("Session");
+        TestConsole.Output.ShouldContain("Seal");
+        TestConsole.Output.ShouldContain("Sealed");
+        TestConsole.Output.ShouldContain("Summary");
+        TestConsole.Output.ShouldContain("Succeeded");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithQuiet_SuppressesInfoButKeepsWarnings()
     {
         // Arrange
@@ -813,7 +1056,9 @@ public class DecryptCommandTests : CommandTestBase
             Writer,
             fileSystem ?? FileSystem,
             _inputResolver,
-            _outputResolver
+            _outputResolver,
+            _passphraseResolver,
+            new DecryptReporter(Writer)
         );
     }
 

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GenerateCommandTests.cs
@@ -18,8 +18,19 @@ public class GenerateCommandTests : CommandTestBase
             .Returns(TestPassphrase);
     }
 
-    private GenerateCommand GetSut(IFileSystem? fileSystem = null) =>
-        new(Writer, fileSystem ?? FileSystem, _passphraseResolver);
+    private GenerateCommand GetSut(
+        IFileSystem? fileSystem = null,
+        IKeyFileWriter? keyFileWriter = null
+    )
+    {
+        IFileSystem fs = fileSystem ?? FileSystem;
+        return new GenerateCommand(
+            Writer,
+            fs,
+            _passphraseResolver,
+            keyFileWriter ?? new KeyFileWriter(fs, Writer)
+        );
+    }
 
     [Fact]
     public void Execute_WithDefaultSettings_GeneratesEncryptedPemKeyPair()
@@ -326,23 +337,14 @@ public class GenerateCommandTests : CommandTestBase
     [Fact]
     public void Execute_WhenWritingPrivateKeyFails_ReturnsErrorAndDisplaysMessage()
     {
-        // Arrange
+        // Arrange — the key file writer fails regardless of OS-specific write plumbing
         string outputPath = Path.Join("test-keys");
-
-        // Use NSubstitute to create a mock that throws IOException when writing private key
-        IFileSystem mockFs = Substitute.For<IFileSystem>();
-        mockFs.Directory.Exists(Arg.Any<string>()).Returns(true);
-        mockFs
-            .Path.Join(Arg.Any<string>(), Arg.Any<string>())
-            .Returns(x => Path.Join((string)x[0], (string)x[1]));
-
-        string privateKeyPath = Path.Join(outputPath, "private_key.pem");
-
-        mockFs
-            .File.When(f => f.WriteAllText(privateKeyPath, Arg.Any<string>()))
+        IKeyFileWriter failingWriter = Substitute.For<IKeyFileWriter>();
+        failingWriter
+            .When(w => w.WritePrivateKey(Arg.Any<string>(), Arg.Any<string>()))
             .Do(_ => throw new IOException("Disk full or write error"));
 
-        GenerateCommand command = GetSut(mockFs);
+        GenerateCommand command = GetSut(keyFileWriter: failingWriter);
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
         // Act

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/GenerateCommandTests.cs
@@ -1,14 +1,31 @@
 using Serilog.Sinks.File.Encrypt.Models;
+using Spectre.Console;
 
 namespace Serilog.Sinks.File.Encrypt.Cli.Tests;
 
 public class GenerateCommandTests : CommandTestBase
 {
-    [Fact]
-    public void Execute_WithDefaultSettings_GeneratesKeyPairSuccessfully()
+    private const string TestPassphrase = "test-passphrase";
+
+    private readonly IPassphraseResolver _passphraseResolver =
+        Substitute.For<IPassphraseResolver>();
+
+    public GenerateCommandTests()
     {
-        // Arrange
-        GenerateCommand command = new(Writer, FileSystem);
+        // Default: behave as if a passphrase source resolved successfully
+        _passphraseResolver
+            .Resolve(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(TestPassphrase);
+    }
+
+    private GenerateCommand GetSut(IFileSystem? fileSystem = null) =>
+        new(Writer, fileSystem ?? FileSystem, _passphraseResolver);
+
+    [Fact]
+    public void Execute_WithDefaultSettings_GeneratesEncryptedPemKeyPair()
+    {
+        // Arrange — 6.0.0 defaults: Pem format, passphrase-encrypted private key
+        GenerateCommand command = GetSut();
         string outputPath = Path.Join("test-keys");
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
@@ -24,24 +41,135 @@ public class GenerateCommandTests : CommandTestBase
 
         FileSystem.Directory.Exists(outputPath).ShouldBeTrue();
 
-        string privateKeyPath = Path.Join(outputPath, "private_key.xml");
+        string privateKeyPath = Path.Join(outputPath, "private_key.pem");
         FileSystem.File.Exists(privateKeyPath).ShouldBeTrue();
         string privateKey = FileSystem.File.ReadAllText(privateKeyPath);
-        privateKey.ShouldNotBeNullOrEmpty();
-        privateKey.ShouldContain("<RSAKeyValue>");
-        privateKey.ShouldContain("<D>"); // Private key should contain private parameters
+        privateKey.ShouldContain("-----BEGIN ENCRYPTED PRIVATE KEY-----");
 
-        string publicKeyPath = Path.Join(outputPath, "public_key.xml");
+        string publicKeyPath = Path.Join(outputPath, "public_key.pem");
         FileSystem.File.Exists(publicKeyPath).ShouldBeTrue();
         string publicKey = FileSystem.File.ReadAllText(publicKeyPath);
-        publicKey.ShouldNotBeNullOrEmpty();
-        publicKey.ShouldContain("<RSAKeyValue>");
-        publicKey.ShouldNotContain("<D>"); // Public key should not contain private parameters
+        publicKey.ShouldContain("-----BEGIN RSA PUBLIC KEY-----");
+        publicKey.ShouldNotContain("PRIVATE");
+
+        // Round trip: the encrypted key imports with the passphrase
+        using var rsa = RSA.Create();
+        Should.NotThrow(() => rsa.ImportFromEncryptedPem(privateKey, TestPassphrase));
 
         TestConsole.Output.ShouldContain("Successfully generated RSA key pair!");
-        TestConsole.Output.ShouldContain("Private Key:");
-        TestConsole.Output.ShouldContain("Public Key:");
+        TestConsole.Output.ShouldContain("passphrase-encrypted");
         TestConsole.Output.ShouldContain("Keep your private key secure");
+    }
+
+    [Fact]
+    public void Execute_NoPassphraseSourceNonInteractive_FailsWithUsageError()
+    {
+        // Arrange — resolver finds nothing and cannot prompt
+        _passphraseResolver
+            .Resolve(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns((string?)null);
+        GenerateCommand command = GetSut();
+        GenerateCommand.Settings settings = new() { OutputPath = "keys" };
+
+        // Act
+        int result = command.Execute(
+            new CommandContext(Arguments, Remaining, "generate", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.UsageError);
+        TestConsole.Output.ShouldContain("No passphrase source available");
+        TestConsole.Output.ShouldContain("--plaintext");
+        FileSystem.AllFiles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Execute_PassphraseSourceFails_FailsWithUsageError()
+    {
+        // Arrange — e.g. --passphrase-env points at an unset variable
+        _passphraseResolver
+            .Resolve(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(_ =>
+                throw new PassphraseResolutionException(
+                    "Environment variable 'MISSING' is not set or empty."
+                )
+            );
+        GenerateCommand command = GetSut();
+        GenerateCommand.Settings settings = new()
+        {
+            OutputPath = "keys",
+            PassphraseEnv = "MISSING",
+        };
+
+        // Act
+        int result = command.Execute(
+            new CommandContext(Arguments, Remaining, "generate", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(ExitCodes.UsageError);
+        TestConsole.Output.ShouldContain("'MISSING' is not set or empty");
+    }
+
+    [Fact]
+    public void Execute_WithPlaintext_SkipsPassphraseResolution()
+    {
+        // Arrange
+        GenerateCommand command = GetSut();
+        string outputPath = Path.Join("test-keys");
+        GenerateCommand.Settings settings = new()
+        {
+            OutputPath = outputPath,
+            KeySize = 2048,
+            Plaintext = true,
+        };
+
+        // Act
+        int result = command.Execute(
+            new CommandContext(Arguments, Remaining, "generate", null),
+            settings,
+            CancellationToken.None
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _passphraseResolver
+            .DidNotReceive()
+            .Resolve(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>());
+        string privateKey = FileSystem.File.ReadAllText(Path.Join(outputPath, "private_key.pem"));
+        privateKey.ShouldContain("-----BEGIN RSA PRIVATE KEY-----");
+        TestConsole.Output.ShouldContain("NOT passphrase-protected");
+    }
+
+    [Fact]
+    public void Settings_XmlWithoutPlaintext_FailsValidation()
+    {
+        GenerateCommand.Settings settings = new() { OutputPath = "keys", Format = KeyFormat.Xml };
+
+        ValidationResult result = settings.Validate();
+
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldNotBeNull();
+        result.Message.ShouldContain("--plaintext");
+    }
+
+    [Fact]
+    public void Settings_PlaintextWithPassphraseSource_FailsValidation()
+    {
+        GenerateCommand.Settings settings = new()
+        {
+            OutputPath = "keys",
+            Plaintext = true,
+            PassphraseEnv = "SOME_VAR",
+        };
+
+        ValidationResult result = settings.Validate();
+
+        result.Successful.ShouldBeFalse();
     }
 
     [Fact]
@@ -49,10 +177,10 @@ public class GenerateCommandTests : CommandTestBase
     {
         // Arrange — a private key already exists at the target path
         string outputPath = Path.Join("test-keys");
-        string privateKeyPath = Path.Join(outputPath, "private_key.xml");
+        string privateKeyPath = Path.Join(outputPath, "private_key.pem");
         const string ExistingKey = "irreplaceable key material";
         FileSystem.AddFile(privateKeyPath, new MockFileData(ExistingKey));
-        GenerateCommand command = new(Writer, FileSystem);
+        GenerateCommand command = GetSut();
         GenerateCommand.Settings settings = new() { OutputPath = outputPath };
 
         // Act
@@ -75,9 +203,9 @@ public class GenerateCommandTests : CommandTestBase
     {
         // Arrange
         string outputPath = Path.Join("test-keys");
-        string privateKeyPath = Path.Join(outputPath, "private_key.xml");
+        string privateKeyPath = Path.Join(outputPath, "private_key.pem");
         FileSystem.AddFile(privateKeyPath, new MockFileData("old key"));
-        GenerateCommand command = new(Writer, FileSystem);
+        GenerateCommand command = GetSut();
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, Force = true };
 
         // Act
@@ -89,21 +217,24 @@ public class GenerateCommandTests : CommandTestBase
 
         // Assert
         result.ShouldBe(0);
-        FileSystem.File.ReadAllText(privateKeyPath).ShouldContain("<RSAKeyValue>");
+        FileSystem
+            .File.ReadAllText(privateKeyPath)
+            .ShouldContain("-----BEGIN ENCRYPTED PRIVATE KEY-----");
         TestConsole.Output.ShouldContain("Successfully generated RSA key pair!");
     }
 
     [Fact]
-    public void Execute_WithXmlFormat_GeneratesKeyPairSuccessfully()
+    public void Execute_WithXmlFormatAndPlaintext_GeneratesKeyPairSuccessfully()
     {
         // Arrange
-        GenerateCommand command = new(Writer, FileSystem);
+        GenerateCommand command = GetSut();
         string outputPath = Path.Join("test-keys");
         GenerateCommand.Settings settings = new()
         {
             OutputPath = outputPath,
             KeySize = 2048,
             Format = KeyFormat.Xml,
+            Plaintext = true,
         };
 
         // Act
@@ -116,39 +247,33 @@ public class GenerateCommandTests : CommandTestBase
         // Assert
         result.ShouldBe(0); // Success
 
-        FileSystem.Directory.Exists(outputPath).ShouldBeTrue();
-
         string privateKeyPath = Path.Join(outputPath, "private_key.xml");
         FileSystem.File.Exists(privateKeyPath).ShouldBeTrue();
         string privateKey = FileSystem.File.ReadAllText(privateKeyPath);
-        privateKey.ShouldNotBeNullOrEmpty();
         privateKey.ShouldContain("<RSAKeyValue>");
         privateKey.ShouldContain("<D>"); // Private key should contain private parameters
 
         string publicKeyPath = Path.Join(outputPath, "public_key.xml");
         FileSystem.File.Exists(publicKeyPath).ShouldBeTrue();
         string publicKey = FileSystem.File.ReadAllText(publicKeyPath);
-        publicKey.ShouldNotBeNullOrEmpty();
         publicKey.ShouldContain("<RSAKeyValue>");
         publicKey.ShouldNotContain("<D>"); // Public key should not contain private parameters
 
         TestConsole.Output.ShouldContain("Successfully generated RSA key pair!");
-        TestConsole.Output.ShouldContain("Private Key:");
-        TestConsole.Output.ShouldContain("Public Key:");
-        TestConsole.Output.ShouldContain("Keep your private key secure");
     }
 
     [Fact]
-    public void Execute_WithPemFormat_GeneratesKeyPairSuccessfully()
+    public void Execute_WithPemFormatAndPlaintext_GeneratesUnencryptedPemKeyPair()
     {
         // Arrange
-        GenerateCommand command = new(Writer, FileSystem);
+        GenerateCommand command = GetSut();
         string outputPath = Path.Join("test-keys");
         GenerateCommand.Settings settings = new()
         {
             OutputPath = outputPath,
             KeySize = 2048,
             Format = KeyFormat.Pem,
+            Plaintext = true,
         };
 
         // Act
@@ -161,25 +286,12 @@ public class GenerateCommandTests : CommandTestBase
         // Assert
         result.ShouldBe(0); // Success
 
-        FileSystem.Directory.Exists(outputPath).ShouldBeTrue();
-
-        string privateKeyPath = Path.Join(outputPath, "private_key.pem");
-        FileSystem.File.Exists(privateKeyPath).ShouldBeTrue();
-        string privateKey = FileSystem.File.ReadAllText(privateKeyPath);
-        privateKey.ShouldNotBeNullOrEmpty();
+        string privateKey = FileSystem.File.ReadAllText(Path.Join(outputPath, "private_key.pem"));
         privateKey.ShouldContain("-----BEGIN RSA PRIVATE KEY-----");
 
-        string publicKeyPath = Path.Join(outputPath, "public_key.pem");
-        FileSystem.File.Exists(publicKeyPath).ShouldBeTrue();
-        string publicKey = FileSystem.File.ReadAllText(publicKeyPath);
-        publicKey.ShouldNotBeNullOrEmpty();
+        string publicKey = FileSystem.File.ReadAllText(Path.Join(outputPath, "public_key.pem"));
         publicKey.ShouldContain("-----BEGIN RSA PUBLIC KEY-----");
-        publicKey.ShouldNotContain("PRIVATE"); // Public key should not contain private parameters
-
-        TestConsole.Output.ShouldContain("Successfully generated RSA key pair!");
-        TestConsole.Output.ShouldContain("Private Key:");
-        TestConsole.Output.ShouldContain("Public Key:");
-        TestConsole.Output.ShouldContain("Keep your private key secure");
+        publicKey.ShouldNotContain("PRIVATE");
     }
 
     [Fact]
@@ -195,7 +307,7 @@ public class GenerateCommandTests : CommandTestBase
             .Directory.When(d => d.CreateDirectory(Arg.Any<string>()))
             .Do(_ => throw new UnauthorizedAccessException("Access denied to create directory"));
 
-        GenerateCommand command = new(Writer, mockFs);
+        GenerateCommand command = GetSut(mockFs);
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
         // Act
@@ -224,13 +336,13 @@ public class GenerateCommandTests : CommandTestBase
             .Path.Join(Arg.Any<string>(), Arg.Any<string>())
             .Returns(x => Path.Join((string)x[0], (string)x[1]));
 
-        string privateKeyPath = Path.Join(outputPath, "private_key.xml");
+        string privateKeyPath = Path.Join(outputPath, "private_key.pem");
 
         mockFs
             .File.When(f => f.WriteAllText(privateKeyPath, Arg.Any<string>()))
             .Do(_ => throw new IOException("Disk full or write error"));
 
-        GenerateCommand command = new(Writer, mockFs);
+        GenerateCommand command = GetSut(mockFs);
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
         // Act
@@ -253,7 +365,7 @@ public class GenerateCommandTests : CommandTestBase
         string outputPath = Path.Join("test-keys");
 
         // Use a real file system but an invalid key size that will cause CryptographicException
-        GenerateCommand command = new(Writer, FileSystem);
+        GenerateCommand command = GetSut();
         GenerateCommand.Settings settings = new()
         {
             OutputPath = outputPath,
@@ -278,7 +390,7 @@ public class GenerateCommandTests : CommandTestBase
         // Arrange
         string outputPath = Path.Join("new-test-keys");
 
-        GenerateCommand command = new(Writer, FileSystem);
+        GenerateCommand command = GetSut();
         GenerateCommand.Settings settings = new() { OutputPath = outputPath, KeySize = 2048 };
 
         FileSystem.Directory.Exists(outputPath).ShouldBeFalse();

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ExampleIntegrationTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ExampleIntegrationTests.cs
@@ -53,9 +53,9 @@ public class ExampleIntegrationTests : CliIntegrationTestBase
     [Fact]
     public async Task Generate_WithQuiet_ParsesAndSucceeds()
     {
-        // Act
+        // Act — --plaintext keeps the run independent of passphrase sources/interactivity
         CommandAppResult result = await Tester.RunAsync(
-            ["generate", "-o", "keys", "-q"],
+            ["generate", "-o", "keys", "-q", "--plaintext"],
             TestContext.Current.CancellationToken
         );
 

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ServiceCollectionExtensionsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ServiceCollectionExtensionsTests.cs
@@ -48,7 +48,7 @@ public class ServiceCollectionExtensionsTests
         services.AddCliServices();
 
         // Assert - Verify no services are accidentally added or removed
-        services.Count.ShouldBe(6);
+        services.Count.ShouldBe(8);
 
         // Verify IFileSystem is registered
         services
@@ -81,6 +81,16 @@ public class ServiceCollectionExtensionsTests
             .FirstOrDefault(s => s.ServiceType == typeof(IPassphraseResolver))
             .ShouldNotBeNull()
             .And(x => x.Lifetime.ShouldBe(ServiceLifetime.Singleton));
+
+        services
+            .FirstOrDefault(s => s.ServiceType == typeof(IKeyFileWriter))
+            .ShouldNotBeNull()
+            .And(x => x.Lifetime.ShouldBe(ServiceLifetime.Singleton));
+
+        services
+            .FirstOrDefault(s => s.ServiceType == typeof(IDecryptReporter))
+            .ShouldNotBeNull()
+            .And(x => x.Lifetime.ShouldBe(ServiceLifetime.Singleton));
     }
 
     [Fact]
@@ -94,7 +104,7 @@ public class ServiceCollectionExtensionsTests
         services.AddCliServices();
 
         // Assert
-        services.Count.ShouldBe(6); // Should still only have 6 services, no duplicates
+        services.Count.ShouldBe(8); // Should still only have 8 services, no duplicates
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ServiceCollectionExtensionsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/ServiceCollectionExtensionsTests.cs
@@ -48,7 +48,7 @@ public class ServiceCollectionExtensionsTests
         services.AddCliServices();
 
         // Assert - Verify no services are accidentally added or removed
-        services.Count.ShouldBe(5);
+        services.Count.ShouldBe(6);
 
         // Verify IFileSystem is registered
         services
@@ -76,6 +76,11 @@ public class ServiceCollectionExtensionsTests
             .FirstOrDefault(s => s.ServiceType == typeof(IConsoleWriter))
             .ShouldNotBeNull()
             .And(x => x.Lifetime.ShouldBe(ServiceLifetime.Singleton));
+
+        services
+            .FirstOrDefault(s => s.ServiceType == typeof(IPassphraseResolver))
+            .ShouldNotBeNull()
+            .And(x => x.Lifetime.ShouldBe(ServiceLifetime.Singleton));
     }
 
     [Fact]
@@ -89,7 +94,7 @@ public class ServiceCollectionExtensionsTests
         services.AddCliServices();
 
         // Assert
-        services.Count.ShouldBe(5); // Should still only have 5 services, no duplicates
+        services.Count.ShouldBe(6); // Should still only have 6 services, no duplicates
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/KeyFileWriterTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/KeyFileWriterTests.cs
@@ -1,0 +1,111 @@
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Serilog.Sinks.File.Encrypt.Cli.Tests;
+
+public class KeyFileWriterTests : CommandTestBase
+{
+    private KeyFileWriter GetSut() => new(FileSystem, Writer);
+
+    [Fact]
+    public void WritePrivateKey_WritesContents()
+    {
+        // Arrange
+        FileSystem.AddDirectory("keys");
+        string path = Path.Join("keys", "private_key.pem");
+
+        // Act
+        GetSut().WritePrivateKey(path, "private key material");
+
+        // Assert
+        FileSystem.File.ReadAllText(path).ShouldBe("private key material");
+    }
+
+    [Fact]
+    public void WritePublicKey_WritesContents()
+    {
+        // Arrange
+        FileSystem.AddDirectory("keys");
+        string path = Path.Join("keys", "public_key.pem");
+
+        // Act
+        GetSut().WritePublicKey(path, "public key material");
+
+        // Assert
+        FileSystem.File.ReadAllText(path).ShouldBe("public key material");
+    }
+
+    [Fact]
+    public void WritePrivateKey_OverwritesExistingContents()
+    {
+        // Arrange — --force flows reach the writer with an existing file
+        string path = Path.Join("keys", "private_key.pem");
+        FileSystem.AddFile(path, new MockFileData("old key"));
+
+        // Act
+        GetSut().WritePrivateKey(path, "new key");
+
+        // Assert
+        FileSystem.File.ReadAllText(path).ShouldBe("new key");
+    }
+
+    [Fact]
+    public void WritePrivateKey_OnUnix_RestrictsModeToOwnerOnly()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Unix file modes do not apply on Windows.");
+            return;
+        }
+
+        // Arrange
+        FileSystem.AddDirectory("keys");
+        string path = Path.Join("keys", "private_key.pem");
+
+        // Act
+        GetSut().WritePrivateKey(path, "private key material");
+
+        // Assert — 600
+        FileSystem
+            .File.GetUnixFileMode(path)
+            .ShouldBe(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    [Fact]
+    public void WritePrivateKey_OnWindowsRealFileSystem_RestrictsAclToCurrentUser()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Windows ACLs only.");
+            return;
+        }
+
+        // Arrange — the ACL path only runs against the real file system
+        string dir = Path.Join(Path.GetTempPath(), $"keywriter_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        string path = Path.Join(dir, "private_key.pem");
+        var realFs = new FileSystem();
+        KeyFileWriter sut = new(realFs, Writer);
+
+        try
+        {
+            // Act
+            sut.WritePrivateKey(path, "private key material");
+
+            // Assert — inheritance off, exactly one rule: current user, full control
+            FileSecurity security = new FileInfo(path).GetAccessControl();
+            var rules = security
+                .GetAccessRules(true, true, typeof(SecurityIdentifier))
+                .Cast<FileSystemAccessRule>()
+                .ToList();
+            rules.Count.ShouldBe(1);
+            rules[0].IdentityReference.ShouldBe(WindowsIdentity.GetCurrent().User);
+            rules[0].AccessControlType.ShouldBe(AccessControlType.Allow);
+            rules[0].IsInherited.ShouldBeFalse();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/PassphraseResolverTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/PassphraseResolverTests.cs
@@ -1,0 +1,159 @@
+namespace Serilog.Sinks.File.Encrypt.Cli.Tests;
+
+public class PassphraseResolverTests : IDisposable
+{
+    private readonly TestConsole _console = new();
+    private readonly MockFileSystem _fileSystem = new();
+
+    private PassphraseResolver GetSut() => new(_console, _fileSystem);
+
+    public void Dispose()
+    {
+        _console.Dispose();
+        Environment.SetEnvironmentVariable(IPassphraseResolver.DefaultEnvironmentVariable, null);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Resolve_FromFile_ReturnsFirstLine()
+    {
+        _fileSystem.AddFile("pass.txt", new MockFileData("secret-line\nsecond line"));
+
+        string? result = GetSut().Resolve("pass.txt", passphraseEnv: null, confirm: false);
+
+        result.ShouldBe("secret-line");
+    }
+
+    [Fact]
+    public void Resolve_MissingFile_Throws()
+    {
+        Should
+            .Throw<PassphraseResolutionException>(() =>
+                GetSut().Resolve("nope.txt", passphraseEnv: null, confirm: false)
+            )
+            .Message.ShouldContain("does not exist");
+    }
+
+    [Fact]
+    public void Resolve_EmptyFile_Throws()
+    {
+        _fileSystem.AddFile("empty.txt", new MockFileData(string.Empty));
+
+        Should
+            .Throw<PassphraseResolutionException>(() =>
+                GetSut().Resolve("empty.txt", passphraseEnv: null, confirm: false)
+            )
+            .Message.ShouldContain("empty");
+    }
+
+    [Fact]
+    public void Resolve_FromNamedEnvironmentVariable_ReturnsValue()
+    {
+        string name = $"CLI_TEST_PASS_{Guid.NewGuid():N}";
+        try
+        {
+            Environment.SetEnvironmentVariable(name, "env-secret");
+
+            string? result = GetSut().Resolve(passphraseFile: null, name, confirm: false);
+
+            result.ShouldBe("env-secret");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+
+    [Fact]
+    public void Resolve_UnsetNamedEnvironmentVariable_Throws()
+    {
+        string name = $"CLI_TEST_PASS_{Guid.NewGuid():N}";
+
+        Should
+            .Throw<PassphraseResolutionException>(() =>
+                GetSut().Resolve(passphraseFile: null, name, confirm: false)
+            )
+            .Message.ShouldContain(name);
+    }
+
+    [Fact]
+    public void Resolve_FallbackEnvironmentVariable_IsUsedWhenNoSourceGiven()
+    {
+        Environment.SetEnvironmentVariable(
+            IPassphraseResolver.DefaultEnvironmentVariable,
+            "fallback-secret"
+        );
+
+        string? result = GetSut()
+            .Resolve(passphraseFile: null, passphraseEnv: null, confirm: false);
+
+        result.ShouldBe("fallback-secret");
+    }
+
+    [Fact]
+    public void Resolve_NoSourceNonInteractive_ReturnsNull()
+    {
+        // TestConsole is non-interactive by default
+        string? result = GetSut()
+            .Resolve(passphraseFile: null, passphraseEnv: null, confirm: false);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_InteractivePrompt_ReturnsEnteredPassphrase()
+    {
+        _console.Interactive();
+        _console.Input.PushTextWithEnter("prompted-secret");
+
+        string? result = GetSut()
+            .Resolve(passphraseFile: null, passphraseEnv: null, confirm: false);
+
+        result.ShouldBe("prompted-secret");
+    }
+
+    [Fact]
+    public void Resolve_InteractiveConfirmMatch_ReturnsPassphrase()
+    {
+        _console.Interactive();
+        _console.Input.PushTextWithEnter("prompted-secret");
+        _console.Input.PushTextWithEnter("prompted-secret");
+
+        string? result = GetSut().Resolve(passphraseFile: null, passphraseEnv: null, confirm: true);
+
+        result.ShouldBe("prompted-secret");
+    }
+
+    [Fact]
+    public void Resolve_InteractiveConfirmMismatch_Throws()
+    {
+        _console.Interactive();
+        _console.Input.PushTextWithEnter("first-entry");
+        _console.Input.PushTextWithEnter("different-entry");
+
+        Should
+            .Throw<PassphraseResolutionException>(() =>
+                GetSut().Resolve(passphraseFile: null, passphraseEnv: null, confirm: true)
+            )
+            .Message.ShouldContain("do not match");
+    }
+
+    [Fact]
+    public void Resolve_FileTakesPrecedenceOverEnv()
+    {
+        _fileSystem.AddFile("pass.txt", new MockFileData("file-secret"));
+        string name = $"CLI_TEST_PASS_{Guid.NewGuid():N}";
+        try
+        {
+            Environment.SetEnvironmentVariable(name, "env-secret");
+
+            string? result = GetSut().Resolve("pass.txt", name, confirm: false);
+
+            result.ShouldBe("file-secret");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+}

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
@@ -61,6 +61,87 @@ public class CryptographicUtilsTests : EncryptionTestBase
     }
 
     [Fact]
+    public void GenerateRsaKeyPair_DefaultFormat_IsPem()
+    {
+        // Arrange, Act — 6.0.0 flipped the default from Xml to Pem
+        (string publicKey, string privateKey) = CryptographicUtils.GenerateRsaKeyPair();
+
+        // Assert
+        publicKey.ShouldStartWith("-----BEGIN RSA PUBLIC KEY-----");
+        privateKey.ShouldStartWith("-----BEGIN RSA PRIVATE KEY-----");
+    }
+
+    [Fact]
+    public void GenerateRsaKeyPair_WithPassphrase_ProducesEncryptedPkcs8ThatRoundTrips()
+    {
+        // Arrange
+        const string Passphrase = "correct horse battery staple";
+
+        // Act
+        (string publicKey, string privateKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            Passphrase
+        );
+
+        // Assert — encrypted PKCS#8 private key, plaintext public key
+        privateKey.ShouldStartWith("-----BEGIN ENCRYPTED PRIVATE KEY-----");
+        publicKey.ShouldStartWith("-----BEGIN RSA PUBLIC KEY-----");
+
+        using var rsa = RSA.Create();
+        Should.NotThrow(() => rsa.ImportFromEncryptedPem(privateKey, Passphrase));
+
+        // The imported key pair must actually match the exported public key
+        using var publicRsa = RSA.Create();
+        publicRsa.FromString(publicKey);
+        byte[] cipher = publicRsa.Encrypt([1, 2, 3], RSAEncryptionPadding.OaepSHA256);
+        rsa.Decrypt(cipher, RSAEncryptionPadding.OaepSHA256).ShouldBe([1, 2, 3]);
+    }
+
+    [Fact]
+    public void GenerateRsaKeyPair_WithPassphrase_WrongPassphraseFailsImport()
+    {
+        // Arrange
+        (_, string privateKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "right passphrase"
+        );
+
+        // Act & Assert
+        using var rsa = RSA.Create();
+        Should.Throw<CryptographicException>(() =>
+            rsa.ImportFromEncryptedPem(privateKey, "wrong passphrase")
+        );
+    }
+
+    [Fact]
+    public void GenerateRsaKeyPair_XmlWithPassphrase_ThrowsNotSupported()
+    {
+        Should
+            .Throw<NotSupportedException>(() =>
+                CryptographicUtils.GenerateRsaKeyPair(2048, KeyFormat.Xml, "passphrase")
+            )
+            .Message.ShouldContain("Pem");
+    }
+
+    [Fact]
+    public void GenerateRsaKeyPair_EmptyPassphrase_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            CryptographicUtils.GenerateRsaKeyPair(2048, KeyFormat.Pem, ReadOnlySpan<char>.Empty)
+        );
+    }
+
+    [Fact]
+    public void GenerateRsaKeyPair_WithPassphrase_EnforcesMinimumKeySize()
+    {
+        Should.Throw<CryptographicException>(() =>
+            CryptographicUtils.GenerateRsaKeyPair(1024, KeyFormat.Pem, "passphrase")
+        );
+    }
+
+    [Fact]
     public void InitializeRsa_FromUnknown_ThrowsCryptographicException()
     {
         // Arrange, Act
@@ -284,7 +365,7 @@ public class CryptographicUtilsTests : EncryptionTestBase
         const string OriginalText = "Testing 4096-bit RSA key with encrypted stream!";
 
         using var rsa = RSA.Create();
-        rsa.FromXmlString(publicKey);
+        rsa.FromString(publicKey);
         EncryptionOptions options = new(rsa, "4096");
         LocalKeyProvider keyProvider = new("4096", privateKey);
         DecryptionOptions decryptionOptions = new() { KeyProvider = keyProvider };

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/CryptographicUtilsTests.cs
@@ -142,6 +142,90 @@ public class CryptographicUtilsTests : EncryptionTestBase
     }
 
     [Fact]
+    public void FromString_EncryptedPemWithoutPassphrase_ThrowsWithClearMessage()
+    {
+        (_, string encryptedKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "passphrase"
+        );
+        using var rsa = RSA.Create();
+
+        Should
+            .Throw<CryptographicException>(() => rsa.FromString(encryptedKey))
+            .Message.ShouldContain("passphrase-encrypted");
+    }
+
+    [Fact]
+    public void FromString_EncryptedPemWithPassphrase_Imports()
+    {
+        (_, string encryptedKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "passphrase"
+        );
+        using var rsa = RSA.Create();
+
+        Should.NotThrow(() => rsa.FromString(encryptedKey, "passphrase"));
+        rsa.KeySize.ShouldBe(2048);
+    }
+
+    [Fact]
+    public void FromString_EncryptedPemWithWrongPassphrase_Throws()
+    {
+        (_, string encryptedKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "right"
+        );
+        using var rsa = RSA.Create();
+
+        Should.Throw<CryptographicException>(() => rsa.FromString(encryptedKey, "wrong"));
+    }
+
+    [Fact]
+    public void FromString_EncryptedPemWithEmptyPassphrase_ThrowsWithClearMessage()
+    {
+        (_, string encryptedKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "passphrase"
+        );
+        using var rsa = RSA.Create();
+
+        Should
+            .Throw<CryptographicException>(() =>
+                rsa.FromString(encryptedKey, ReadOnlySpan<char>.Empty)
+            )
+            .Message.ShouldContain("passphrase-encrypted");
+    }
+
+    [Fact]
+    public void FromString_PassphraseOverloadWithUnencryptedKey_IgnoresPassphrase()
+    {
+        (_, string plainKey) = CryptographicUtils.GenerateRsaKeyPair(format: KeyFormat.Pem);
+        using var rsa = RSA.Create();
+
+        Should.NotThrow(() => rsa.FromString(plainKey, "irrelevant"));
+    }
+
+    [Fact]
+    public void IsEncryptedPem_DistinguishesKeyKinds()
+    {
+        (_, string encryptedKey) = CryptographicUtils.GenerateRsaKeyPair(
+            2048,
+            KeyFormat.Pem,
+            "passphrase"
+        );
+        (_, string plainPem) = CryptographicUtils.GenerateRsaKeyPair(format: KeyFormat.Pem);
+        (_, string plainXml) = CryptographicUtils.GenerateRsaKeyPair(format: KeyFormat.Xml);
+
+        CryptographicUtils.IsEncryptedPem(encryptedKey).ShouldBeTrue();
+        CryptographicUtils.IsEncryptedPem(plainPem).ShouldBeFalse();
+        CryptographicUtils.IsEncryptedPem(plainXml).ShouldBeFalse();
+    }
+
+    [Fact]
     public void InitializeRsa_FromUnknown_ThrowsCryptographicException()
     {
         // Arrange, Act

--- a/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptedLogStreamAsyncTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Tests/EncryptedLogStreamAsyncTests.cs
@@ -141,7 +141,7 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         (string publicKey, _) = CryptographicUtils.GenerateRsaKeyPair();
         using MemoryStream fs = new();
         using RSA rsa = RSA.Create();
-        rsa.FromXmlString(publicKey);
+        rsa.FromString(publicKey);
         EncryptionOptions options = new(rsa);
         await using LogWriter logWriter = new(fs, options);
 
@@ -162,7 +162,7 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         (string publicKey, _) = CryptographicUtils.GenerateRsaKeyPair();
         using MemoryStream fs = new();
         using RSA rsa = RSA.Create();
-        rsa.FromXmlString(publicKey);
+        rsa.FromString(publicKey);
         EncryptionOptions options = new(rsa);
         await using LogWriter logWriter = new(fs, options);
 
@@ -181,7 +181,7 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         (string publicKey, _) = CryptographicUtils.GenerateRsaKeyPair();
         using MemoryStream fs = new();
         using RSA rsa = RSA.Create();
-        rsa.FromXmlString(publicKey);
+        rsa.FromString(publicKey);
         EncryptionOptions options = new(rsa);
         await using LogWriter logWriter = new(fs, options);
 
@@ -202,7 +202,7 @@ public sealed class EncryptedLogStreamAsyncTests : EncryptionTestBase
         (string publicKey, _) = CryptographicUtils.GenerateRsaKeyPair();
         using MemoryStream fs = new();
         using RSA rsa = RSA.Create();
-        rsa.FromXmlString(publicKey);
+        rsa.FromString(publicKey);
         EncryptionOptions options = new(rsa);
         await using LogWriter logWriter = new(fs, options);
 


### PR DESCRIPTION
Closes #97. **Stacked on #104** — merge order: #102 → #103 → #104 → this. Base is `feature/85-output-path-hardening`.

## What changed

**Core (`CryptographicUtils`)**
- New overload `GenerateRsaKeyPair(int keySize, KeyFormat format, ReadOnlySpan<char> passphrase)` exporting the private key as an encrypted PKCS#8 PEM (`ENCRYPTED PRIVATE KEY`; PBKDF2-SHA256, 600,000 iterations, AES-256-CBC). `KeyFormat.Xml` + passphrase throws `NotSupportedException`; empty passphrase throws `ArgumentException`; the 2048-bit minimum still applies. BCL-only — Core keeps zero dependencies.
- **Breaking:** the existing overload's default `format` flipped `Xml` → `Pem`. `FromString` reads both transparently, so round-trip callers are unaffected; only code asserting XML shape of default output breaks.

**CLI `generate`**
- Private key is passphrase-encrypted **by default**. Passphrase resolution order: `--passphrase-file` (first line) → `--passphrase-env <NAME>` → `SERILOG_ENCRYPT_PASSPHRASE` env var → interactive hidden prompt with confirmation. Deliberately no `--passphrase` argv option (shell history / process-list leakage).
- `--plaintext` is the explicit opt-out and is required for `--format Xml` (validated). Non-interactive with no source and no `--plaintext` → exit 2 with guidance.
- New defaults (breaking): format **Pem**, key size **3072**; the `-k` short is removed from `--key-size` so `-k` can consistently mean "key file" on `decrypt` (#98).
- New `IPassphraseResolver`/`PassphraseResolver` service — shared with the decrypt-side work in #98.

## Tests

- Core: encrypted PEM round-trips via `ImportFromEncryptedPem` and matches the exported public key; wrong passphrase fails; Xml+passphrase throws; empty passphrase throws; minimum key size enforced; default format is Pem.
- Resolver: file/env/fallback-env precedence, missing/empty sources throw, non-interactive returns null, interactive prompt + confirm match/mismatch via `TestConsole`.
- Command: default settings produce an importable encrypted key; no-source non-interactive → exit 2; failing source → exit 2; `--plaintext` skips resolution; Xml validation; refusal/`--force` paths updated for `.pem`.
- `dotnet make Test` green on net8.0 + net10.0 (101 CLI tests, 76 Encrypt tests).

## Notes for review

- Existing tests that called `FromXmlString` on default-format output were switched to the format-agnostic `FromString`.
- The nuget readmes (CLI + Encrypt) and CHANGELOG document the new defaults and the no-argv-passphrase rationale.
