### PR TITLE
Cleanup: Remove redundant default initializers

### DIFF
--- a/src/Serilog.Sinks.File.Decrypt/Models/DecryptionOptions.cs
+++ b/src/Serilog.Sinks.File.Decrypt/Models/DecryptionOptions.cs
@@ -40,5 +40,5 @@ public sealed record DecryptionOptions
     /// Leave this off (default) for crash-tolerant reading: a log whose writer crashed is
     /// indistinguishable from a truncated one and still decrypts fully.
     /// </remarks>
-    public bool RequireSealed { get; init; } = false;
+    public bool RequireSealed { get; init; }
 };

--- a/src/Serilog.Sinks.File.Decrypt/Models/DecryptionResult.cs
+++ b/src/Serilog.Sinks.File.Decrypt/Models/DecryptionResult.cs
@@ -10,13 +10,13 @@ public sealed class DecryptionResult
     /// Number of successfully decrypted sessions.
     /// A session is defined as a complete set of log messages that were encrypted together.
     /// </summary>
-    public int DecryptedSessions { get; init; } = 0;
+    public int DecryptedSessions { get; init; }
 
     /// <summary>
     /// Number of successfully decrypted messages.
     /// This counts individual log messages that were successfully decrypted, regardless of session boundaries.
     /// </summary>
-    public int DecryptedMessages { get; init; } = 0;
+    public int DecryptedMessages { get; init; }
 
     /// <summary>
     /// The number of decryption errors encountered while processing what appears
@@ -24,7 +24,7 @@ public sealed class DecryptionResult
     /// such as missing or corrupted headers that prevent identifying the session's
     /// decryption parameters.
     /// </summary>
-    public int FailedHeaders { get; init; } = 0;
+    public int FailedHeaders { get; init; }
 
     /// <summary>
     /// The number of decryption errors encountered while processing individual log messages.
@@ -32,7 +32,7 @@ public sealed class DecryptionResult
     /// that occur after successfully identifying the session. These errors may be due to data corruption,
     /// incorrect decryption keys, or other issues that prevent successful decryption of the message content
     /// </summary>
-    public int FailedMessages { get; init; } = 0;
+    public int FailedMessages { get; init; }
 
     /// <summary>
     /// <para>
@@ -45,7 +45,7 @@ public sealed class DecryptionResult
     /// while a low number suggests that most of the file was successfully decrypted with minimal issues.
     /// </para>
     /// </summary>
-    public int ResyncAttempts { get; init; } = 0;
+    public int ResyncAttempts { get; init; }
 
     /// <summary>
     /// Per-session results in the order the sessions were encountered in the input, including

--- a/src/Serilog.Sinks.File.Decrypt/Serilog.Sinks.File.Decrypt.csproj.DotSettings
+++ b/src/Serilog.Sinks.File.Decrypt/Serilog.Sinks.File.Decrypt.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=readers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReporter.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReporter.cs
@@ -87,13 +87,12 @@ public sealed class DecryptReporter(IConsoleWriter writer) : IDecryptReporter
     private static string FormatSeal(SessionReport session) =>
         session.SealStatus switch
         {
-            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.Sealed) => "[green]Sealed[/]",
-            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.NotApplicable) =>
-                "[dim]v1 (n/a)[/]",
-            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.Unsealed) => "[yellow]Unsealed[/]",
-            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.SealCountMismatch) =>
+            nameof(Decrypt.Models.SealStatus.Sealed) => "[green]Sealed[/]",
+            nameof(Decrypt.Models.SealStatus.NotApplicable) => "[dim]v1 (n/a)[/]",
+            nameof(Decrypt.Models.SealStatus.Unsealed) => "[yellow]Unsealed[/]",
+            nameof(Decrypt.Models.SealStatus.SealCountMismatch) =>
                 $"[red]Count mismatch (declared {session.DeclaredFrameCount})[/]",
-            nameof(Serilog.Sinks.File.Decrypt.Models.SealStatus.SealInvalid) => "[red]Invalid[/]",
+            nameof(Decrypt.Models.SealStatus.SealInvalid) => "[red]Invalid[/]",
             _ => Markup.Escape(session.SealStatus),
         };
 }


### PR DESCRIPTION
and shorten type references

Remove explicit ` = false;` and ` = 0;` initializers from `DecryptionOptions` and `DecryptionResult` properties, as these are implicit defaults for `bool` and `int` respectively.

Shorten fully-qualified type references in `DecryptReporter`'s `nameof` expressions for improved readability.

Add ReSharper settings to ignore the `readers` folder for namespace provision.