### PR TITLE
Fix CLI: reject unknown options and add --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,17 @@ new `DecryptionResult.NothingDecrypted` property (additive, non-breaking).
   detected `SealCountMismatch` always throws in `ThrowException` mode, even without the flag.
 - **CLI `--require-sealed`** — the `decrypt` command reports per-session seal status and, combined
   with `--strict`, fails on unsealed/legacy sessions.
+- **CLI `--version`** — `serilog-encrypt --version` (or `-v` at the root) prints the tool version,
+  sourced from the MinVer-stamped assembly informational version. Inside a command, `-v` remains
+  `--verbose`.
+
+### Fixed
+
+- **CLI now rejects unknown options** instead of silently ignoring them. Spectre.Console.Cli
+  does not reject unrecognized options by default, so an invocation like
+  `generate -o keys -k 4096` dropped the unknown `-k` and ran with the default key size,
+  exiting `0`. Strict parsing is now enabled, so any unknown option fails with an "Unknown
+  option" diagnostic and exit code `2` (usage error).
 
 ### Notes
 

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Infrastructure/CommandAppConfiguration.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog.Sinks.File.Encrypt.Cli.Commands;
 using Spectre.Console.Cli;
@@ -35,6 +36,8 @@ public static class CommandAppConfiguration
         return c =>
         {
             c.SetApplicationName("serilog-encrypt");
+            c.SetApplicationVersion(GetInformationalVersion());
+            c.UseStrictParsing();
             c.AddCommand<GenerateCommand>(Generate)
                 .WithDescription(
                     "Generate a new RSA key pair for log encryption. The private key is "
@@ -74,5 +77,20 @@ public static class CommandAppConfiguration
                 .WithExample(Decrypt, "./logs/*.log", "-k", PrivateKey, "--audit-log", "audit.log");
             c.ValidateExamples();
         };
+    }
+
+    /// <summary>
+    /// Resolves the version shown by <c>--version</c> from the assembly's MinVer-stamped
+    /// informational version, dropping any <c>+build</c> metadata. Falls back to "unknown"
+    /// when the attribute is absent (e.g. a MinVer-skipped Debug build).
+    /// </summary>
+    private static string GetInformationalVersion()
+    {
+        string? informational = Assembly
+            .GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        return string.IsNullOrEmpty(informational) ? "unknown" : informational.Split('+')[0];
     }
 }

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/StrictParsingTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/StrictParsingTests.cs
@@ -1,0 +1,56 @@
+using Spectre.Console.Cli.Testing;
+
+namespace Serilog.Sinks.File.Encrypt.Cli.Tests.Integration;
+
+/// <summary>
+/// Guards <see cref="CommandAppConfiguration"/>'s <c>UseStrictParsing()</c>: unknown options
+/// must be rejected as a usage error rather than silently ignored. Without strict parsing
+/// Spectre.Console.Cli collects unrecognized options into the remaining arguments and the
+/// command runs on with its defaults (e.g. <c>generate -k 4096</c> would silently keep the
+/// default key size).
+/// </summary>
+public class StrictParsingTests : CliIntegrationTestBase
+{
+    [Fact]
+    public async Task Generate_UnknownShortOption_IsRejectedAsUsageError()
+    {
+        // Act — '-k' is not a defined option; only '--key-size' is.
+        CommandAppResult result = await Tester.RunAsync(
+            ["generate", "-o", "keys", "-k", "4096", "--plaintext"],
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert — Spectre reports parse failures as -1; Program normalizes to 2.
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(ExitCodes.UsageError, ExitCodes.Normalize(result.ExitCode));
+        Assert.Contains("Unknown option", result.Output);
+    }
+
+    [Fact]
+    public async Task Generate_KeySizeLongOption_IsStillAccepted()
+    {
+        // Act — the supported spelling must keep working under strict parsing.
+        CommandAppResult result = await Tester.RunAsync(
+            ["generate", "-o", "keys", "--key-size", "4096", "--plaintext"],
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert
+        Assert.Equal(ExitCodes.Success, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Decrypt_UnknownOption_IsRejectedAsUsageError()
+    {
+        // Act
+        CommandAppResult result = await Tester.RunAsync(
+            ["decrypt", "app.log", "-k", "private_key.pem", "--nope"],
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(ExitCodes.UsageError, ExitCodes.Normalize(result.ExitCode));
+        Assert.Contains("Unknown option", result.Output);
+    }
+}

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/VersionOptionTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/Integration/VersionOptionTests.cs
@@ -1,0 +1,42 @@
+using Spectre.Console.Cli.Testing;
+
+namespace Serilog.Sinks.File.Encrypt.Cli.Tests.Integration;
+
+/// <summary>
+/// Guards <see cref="CommandAppConfiguration"/>'s <c>SetApplicationVersion(...)</c>. With
+/// strict parsing enabled the app-level <c>--version</c> option must be explicitly configured,
+/// otherwise it would be rejected as an unknown option. The version flag lives at the root
+/// (before any command); <c>-v</c> inside a command still means <c>--verbose</c>.
+/// </summary>
+public class VersionOptionTests : CliIntegrationTestBase
+{
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("-v")]
+    public async Task RootVersionOption_PrintsVersion_ExitZero(string flag)
+    {
+        // Act
+        CommandAppResult result = await Tester.RunAsync(
+            [flag],
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert — resolves the assembly version; must not be an "Unknown option" failure.
+        Assert.Equal(ExitCodes.Success, result.ExitCode);
+        Assert.False(string.IsNullOrWhiteSpace(result.Output));
+        Assert.DoesNotContain("Unknown option", result.Output);
+    }
+
+    [Fact]
+    public async Task CommandLevelVerboseShortFlag_IsNotTreatedAsVersion()
+    {
+        // Act — '-v' after the command name is --verbose, not --version.
+        CommandAppResult result = await Tester.RunAsync(
+            ["generate", "-o", "keys", "-v", "--plaintext"],
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert — the command actually runs (verbose), rather than short-circuiting to version.
+        Assert.Equal(ExitCodes.Success, result.ExitCode);
+    }
+}


### PR DESCRIPTION
## Summary

Two related CLI fixes surfaced while manually testing the 6.0.0 overhaul (test-plan step 2.10).

### 1. Reject unknown options (strict parsing)

Spectre.Console.Cli **does not reject unrecognized options by default** — it collects them into the remaining arguments and runs the command with its defaults. So:

```
serilog-encrypt generate -o keys -k 4096
```

silently **dropped** the unknown `-k` and generated a **default-size (3072) key**, exiting `0`. This affected every command

Enabling `UseStrictParsing()` makes any unknown option fail with Spectre's native `^^ Unknown option` diagnostic and exit code **2** (usage error).

### 2. Wire up `--version`

`--version` was **never actually implemented** — it never printed anything. Now wired up via `SetApplicationVersion(...)`, sourced from the MinVer-stamped `AssemblyInformationalVersion` (`+build` metadata stripped; `"unknown"` fallback for MinVer-skipped Debug builds).

| Invocation | Result |
|---|---|
| `serilog-encrypt --version` / root `-v` | prints version, exit 0 |
| `generate … -v --plaintext` | still `--verbose`, exit 0 |
| `generate … -k 4096` | rejected, exit 2 |

The app-level `-v\|--version` and command-level `-v\|--verbose` coexist via Spectre's standard two-level parsing (version at the root, verbose inside a command).

## Tests

- `StrictParsingTests` — unknown short/long options rejected (exit 2); `--key-size` still accepted.
- `VersionOptionTests` — `--version`/root `-v` print version; command-level `-v` stays verbose.
- Full `dotnet make Test` green on **net8.0 + net10.0**.

## Notes

- No on-disk format impact; CLI-only change.
- CHANGELOG updated under `[6.0.0] - Unreleased` (New Features + Fixed).