### PR TITLE
Fix #111: AllSessionsSealed never vacuously true when nothing was decrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ new EncryptionOptions(rsa, KeyId: "my-key");
 
 - `DecryptionResult` is now `sealed` and gains `Sessions` (`IReadOnlyList<SessionResult>`),
   `UnsealedSessions`, and `AllSessionsSealed`. The existing flat counters are unchanged.
+  `AllSessionsSealed` requires at least one session — an empty result (nothing decrypted)
+  reports `false`, never a vacuous `true`; the `--json` report applies the same rule to its
+  per-file and summary `allSessionsSealed` fields.
 - `DecryptionContext` gains `Version`, `HeaderHash`, `SealNonce`, and `KeyId`; its constructor
   signature changed.
 - Internal writer/reader interfaces (`IFrameWriter`, `ISessionWriter`, `ISessionReader`) changed

--- a/resources/nuget/Serilog.Sinks.File.Decrypt.md
+++ b/resources/nuget/Serilog.Sinks.File.Decrypt.md
@@ -178,7 +178,7 @@ foreach (SessionResult session in result.Sessions)
 }
 
 // Convenience aggregates
-bool trustworthy = result.AllSessionsSealed;   // every session Sealed or v1
+bool trustworthy = result.AllSessionsSealed;   // ≥1 session, every one Sealed or v1
 int suspect      = result.UnsealedSessions;    // Unsealed + SealCountMismatch + SealInvalid
 ```
 
@@ -296,7 +296,8 @@ public sealed class DecryptionResult
     // Per-session detail, in the order sessions appear in the file
     public IReadOnlyList<SessionResult> Sessions { get; init; }
     public int UnsealedSessions  { get; }   // Unsealed + SealCountMismatch + SealInvalid
-    public bool AllSessionsSealed { get; }  // every session Sealed or NotApplicable (v1)
+    public bool AllSessionsSealed { get; }  // ≥1 session and every one Sealed or NotApplicable (v1);
+                                            // false when nothing was decrypted
 }
 ```
 

--- a/src/Serilog.Sinks.File.Decrypt/Models/DecryptionResult.cs
+++ b/src/Serilog.Sinks.File.Decrypt/Models/DecryptionResult.cs
@@ -70,10 +70,13 @@ public sealed class DecryptionResult
         );
 
     /// <summary>
-    /// True when every session either verified as sealed or predates seal support (v1).
+    /// True when at least one session was found and every session either verified as sealed
+    /// or predates seal support (v1). False when the result contains no sessions at all —
+    /// an empty result carries no seal evidence (see <see cref="NothingDecrypted"/>).
     /// </summary>
     public bool AllSessionsSealed =>
-        Sessions.All(s => s.SealStatus is SealStatus.Sealed or SealStatus.NotApplicable);
+        Sessions.Count > 0
+        && Sessions.All(s => s.SealStatus is SealStatus.Sealed or SealStatus.NotApplicable);
 
     /// <summary>
     /// <para>

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Commands/DecryptCommand.cs
@@ -544,7 +544,7 @@ public sealed class DecryptCommand(
             FailedHeaders: 0,
             FailedMessages: 0,
             ResyncAttempts: 0,
-            AllSessionsSealed: true,
+            AllSessionsSealed: false,
             Sessions: [],
             Error: error
         );
@@ -562,9 +562,11 @@ public sealed class DecryptCommand(
             reports.Sum(r => r.ResyncAttempts),
             // Strict, matching the library's RequireSealed semantics: a v1 session
             // (NotApplicable) cannot be verified and therefore counts as not sealed.
-            reports
-                .Where(r => r.Outcome == FileOutcome.Success)
-                .All(r => r.Sessions.All(s => s.SealStatus == nameof(SealStatus.Sealed)))
+            // A run with zero successful files verified nothing, so it is never "all sealed".
+            reports.Any(r => r.Outcome == FileOutcome.Success)
+                && reports
+                    .Where(r => r.Outcome == FileOutcome.Success)
+                    .All(r => r.Sessions.All(s => s.SealStatus == nameof(SealStatus.Sealed)))
         );
     }
 

--- a/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReportModels.cs
+++ b/src/Serilog.Sinks.File.Encrypt.Cli/Services/DecryptReportModels.cs
@@ -57,7 +57,9 @@ public sealed record FileReport(
 /// every session of every successful file is cryptographically verified as sealed — v1
 /// sessions (seal <c>NotApplicable</c>) count as NOT sealed, matching the library's
 /// <c>RequireSealed</c> semantics. Per-file <see cref="FileReport.AllSessionsSealed"/>
-/// keeps the library's v1-tolerant meaning.
+/// keeps the library's v1-tolerant meaning. Both are false when nothing was verified:
+/// the summary flag when no file succeeded, the per-file flag when the file produced no
+/// sessions (failed, refused, or nothing decrypted).
 /// </summary>
 public sealed record RunSummary(
     int Files,

--- a/tests/Serilog.Sinks.File.Decrypt.Tests/DecryptionResultTests.cs
+++ b/tests/Serilog.Sinks.File.Decrypt.Tests/DecryptionResultTests.cs
@@ -35,6 +35,38 @@ public sealed class DecryptionResultTests : EncryptionTestBase
     }
 
     [Fact]
+    public void AllSessionsSealed_FalseWhenNoSessions()
+    {
+        DecryptionResult result = new();
+
+        result.AllSessionsSealed.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(SealStatus.Sealed, true)]
+    [InlineData(SealStatus.NotApplicable, true)]
+    [InlineData(SealStatus.Unsealed, false)]
+    [InlineData(SealStatus.SealCountMismatch, false)]
+    [InlineData(SealStatus.SealInvalid, false)]
+    public void AllSessionsSealed_ReflectsSealStatus(SealStatus status, bool expected)
+    {
+        DecryptionResult result = new()
+        {
+            Sessions =
+            [
+                new SessionResult
+                {
+                    Index = 0,
+                    FormatVersion = 2,
+                    SealStatus = status,
+                },
+            ],
+        };
+
+        result.AllSessionsSealed.ShouldBe(expected);
+    }
+
+    [Fact]
     public async Task SkipMode_WrongKey_ReportsNothingDecrypted()
     {
         // Arrange — encrypt with the test base key, decrypt with a different key
@@ -58,6 +90,7 @@ public sealed class DecryptionResultTests : EncryptionTestBase
         result.NothingDecrypted.ShouldBeTrue();
         result.FailedHeaders.ShouldBeGreaterThan(0);
         output.Length.ShouldBe(0);
+        result.AllSessionsSealed.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/DecryptCommandTests.cs
+++ b/tests/Serilog.Sinks.File.Encrypt.Cli.Tests/DecryptCommandTests.cs
@@ -937,6 +937,15 @@ public class DecryptCommandTests : CommandTestBase
             .GetProperty("outcome")
             .GetString()
             .ShouldBe("NothingDecrypted");
+        // Nothing was verified, so neither flag may claim sealed vacuously
+        doc.RootElement.GetProperty("files")[0]
+            .GetProperty("allSessionsSealed")
+            .GetBoolean()
+            .ShouldBeFalse();
+        doc.RootElement.GetProperty("summary")
+            .GetProperty("allSessionsSealed")
+            .GetBoolean()
+            .ShouldBeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #111.

## What changed

- **`DecryptionResult.AllSessionsSealed`** now requires `Sessions.Count > 0` — an empty result (wrong key, wrong `--id`, junk or empty input) reports `false` instead of a vacuous `true`. XML doc updated to state the rule.
- **CLI `--json` report** applies the same "never claim sealed without evidence" rule:
  - `EmptyReport` (Failed/Refused files) now emits `allSessionsSealed: false` instead of a hardcoded `true`.
  - The strict `summary.allSessionsSealed` aggregate requires at least one Success file.
- Docs updated: `DecryptReportModels` doc comment, both `AllSessionsSealed` mentions in `resources/nuget/Serilog.Sinks.File.Decrypt.md`, and the unreleased 6.0.0 CHANGELOG entry.

## What did NOT change

- **Exit codes.** `DetermineExitCode` checks Failed (1), Refused (2), and NothingDecrypted (4) before the seal check (5), so whenever zero files succeeded one of those already wins — the summary gate is unreachable for exit-code purposes.
- **v1 tolerance.** `NotApplicable` still counts as sealed at the library/per-file level; the strict summary meaning is unchanged.
- No wire-format or on-disk changes.

## Compatibility

`AllSessionsSealed` and `--json` schemaVersion 1 are both new in the unreleased 6.0.0, so there is no breaking-change impact.

## Tests

- New `AllSessionsSealed_FalseWhenNoSessions` and a five-way `SealStatus` theory in `DecryptionResultTests`.
- Added `AllSessionsSealed.ShouldBeFalse()` to the existing wrong-key skip-mode test.
- CLI JSON zero-output test now asserts both `files[0].allSessionsSealed` and `summary.allSessionsSealed` are `false`.
- `dotnet make Test` green locally (net8.0 + net10.0).

Found during the 6.0.0 manual acceptance test pass (TESTPLAN-6.0.0.md §5.3 follow-up).