### PR TITLE
feat: Add example for mixed-version log decryption

### DIFF
--- a/examples/Example.Console/README.md
+++ b/examples/Example.Console/README.md
@@ -26,12 +26,18 @@ Generate fresh encryption keys for this example:
 cd examples/Example.Console
 
 # Generate new RSA keys
-serilog-encrypt generate --output .
+serilog-encrypt generate --output . --format Xml --plaintext
 ```
 
 This creates two files:
 - `public_key.xml` - Used by the application for encryption
 - `private_key.xml` - Used for decryption (keep secure!)
+
+> [!NOTE]
+> XML format is required here because the example project embeds `public_key.xml` as a
+> resource, and `--plaintext` is required for XML keys (only PEM keys support passphrase
+> encryption). For real applications, prefer the CLI's default: a passphrase-protected
+> PEM key pair.
 
 ### 3. Build and Run the Example
 
@@ -82,13 +88,13 @@ Use the CLI tool to decrypt and view the log contents:
 ```bash
 # Decrypt a specific log file (replace the date portion with your actual filename)
 # --id must match the keyId used in EncryptHooks — see Program.cs
-serilog-encrypt decrypt log20251123.txt -k ../../../private_key.xml --id console-key-2026
+serilog-encrypt decrypt log20251123.txt -k ../../../../private_key.xml --id console-key-2026
 
 # Or decrypt all log files in the Logs directory using a glob pattern
-serilog-encrypt decrypt *.txt -k ../../../private_key.xml --id console-key-2026
+serilog-encrypt decrypt *.txt -k ../../../../private_key.xml --id console-key-2026
 
 # Decrypt to a custom output name
-serilog-encrypt decrypt log20251123.txt -k ../../../private_key.xml --id console-key-2026 -o decrypted-log.txt
+serilog-encrypt decrypt log20251123.txt -k ../../../../private_key.xml --id console-key-2026 -o decrypted-log.txt
 
 # View the decrypted content
 cat log20251123.decrypted.txt

--- a/examples/Example.FileBasedApp/README.md
+++ b/examples/Example.FileBasedApp/README.md
@@ -1,0 +1,87 @@
+# Example.FileBasedApp — decrypting mixed-version logs
+
+This example proves that v6.0.0 decrypts **mixed-version log files**: a single encrypted log
+containing sessions written by an old release (v4.0.0, legacy v1 on-disk format) *and* by the
+current release (v2 on-disk format) decrypts in one pass with one key.
+
+The programs are .NET 10 **file-based apps** — standalone `.cs` files run directly with
+`dotnet run <file>.cs`, no project files needed. The directives on the first line declare
+their dependencies:
+
+| File | Dependency | What it does |
+|------|------------|--------------|
+| `v4Log.cs` | `#:package` → `Serilog.Sinks.File.Encrypt` **4.0.0** from NuGet | Appends an encrypted **v1-format** session to `file-based.log` |
+| `vLatestLog.cs` | `#:project` → the in-repo `Serilog.Sinks.File.Encrypt` | Appends an encrypted **v2-format** session (with end-of-log seal) to the same file |
+| `vLatestDecrypt.cs` | `#:project` → the in-repo `Serilog.Sinks.File.Decrypt` | Decrypts the mixed file and prints per-session format version and seal status |
+
+Both writers use the same key (`keyId: "file-based-key"`) and prefix their messages with
+`[v4]` / `[vLatest]` so you can tell which version produced each entry in the decrypted output.
+
+## Prerequisites
+
+- .NET 10 SDK (the repo's `global.json` already pins one)
+- The `serilog-encrypt` CLI for key generation:
+
+  ```bash
+  dotnet tool install --global Serilog.Sinks.File.Encrypt.Cli
+  ```
+
+## Walkthrough
+
+Run everything from this directory.
+
+### 1. Generate a key pair
+
+```bash
+serilog-encrypt generate --output . --format Xml --plaintext
+```
+
+This creates `public_key.xml` and `private_key.xml`, which the programs read directly with
+`File.ReadAllText`. The demo uses plaintext XML keys to stay self-contained and compatible
+with the v4.0.0 package; for real applications prefer the CLI's default — a
+passphrase-protected PEM private key.
+
+### 2. Write logs with both versions
+
+```bash
+dotnet run v4Log.cs
+dotnet run vLatestLog.cs
+```
+
+Run them in any order, as many times as you like — each run appends one more encrypted
+session to `file-based.log`. The point is that decryption works regardless of which version
+wrote which session, as long as you hold the matching private key.
+
+### 3. Decrypt the mixed file
+
+```bash
+dotnet run vLatestDecrypt.cs
+```
+
+After one run of each writer you should see:
+
+```text
+Decrypted 26 message(s) from 2 session(s):
+  Session 0: format v1, 13 message(s), seal: NotApplicable
+  Session 1: format v2, 13 message(s), seal: Sealed
+Decrypted log written to file-based-decrypted.log
+```
+
+Sessions written by v4.0.0 report `format v1` with seal `NotApplicable` (the legacy format
+has no end-of-log seal); sessions written by the current version report `format v2` with
+seal `Sealed`, cryptographically verifying the session was cleanly closed and complete.
+
+Open `file-based-decrypted.log` to see the interleaved `[v4]` and `[vLatest]` entries in
+plain text.
+
+You can also decrypt the same file with the CLI instead of the library:
+
+```bash
+serilog-encrypt decrypt file-based.log -k private_key.xml --id file-based-key
+```
+
+## Starting over
+
+All generated files (`file-based.log`, `file-based-decrypted.log`, and the key pair) are
+gitignored. Delete `file-based.log` and `file-based-decrypted.log` to start a fresh mix;
+keep the keys unless you also want to re-encrypt from scratch.

--- a/examples/Example.FileBasedApp/v4Log.cs
+++ b/examples/Example.FileBasedApp/v4Log.cs
@@ -1,0 +1,25 @@
+#:package Serilog.Sinks.File.Encrypt@4.0.0
+
+using Serilog;
+using Serilog.Core;
+using Serilog.Sinks.File.Encrypt;
+
+string publicKey = File.ReadAllText("public_key.xml");
+
+Logger logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .WriteTo.File(
+        path: "file-based.log",
+        hooks: new EncryptHooks(publicKey, keyId: "file-based-key")
+    )
+    .CreateLogger();
+
+logger.Information("[v4] This is a test log message.");
+for (int i = 0; i < 10; i++)
+{
+    logger.Information("[v4] This is test log message number {LogNumber}.", i);
+}
+logger.Debug("[v4] This is a debug log message.");
+logger.Error("[v4] This is an error log message.");
+await logger.DisposeAsync();
+Console.WriteLine("[v4] Encrypted v1-format session appended to file-based.log");

--- a/examples/Example.FileBasedApp/vLatestDecrypt.cs
+++ b/examples/Example.FileBasedApp/vLatestDecrypt.cs
@@ -1,0 +1,44 @@
+#:project ../../src/Serilog.Sinks.File.Decrypt/Serilog.Sinks.File.Decrypt.csproj
+
+using Serilog.Sinks.File.Decrypt;
+using Serilog.Sinks.File.Decrypt.Models;
+
+string privateKey = File.ReadAllText("private_key.xml");
+
+var options = new DecryptionOptions
+{
+    KeyProvider = new LocalKeyProvider("file-based-key", privateKey),
+};
+
+DecryptionResult result = await DecryptionUtils.DecryptLogFileAsync(
+    "file-based.log",
+    "file-based-decrypted.log",
+    options
+);
+
+if (result.NothingDecrypted)
+{
+    Console.WriteLine("Nothing was decrypted — wrong key, wrong key ID, or not an encrypted log.");
+    return 1;
+}
+
+Console.WriteLine(
+    $"Decrypted {result.DecryptedMessages} message(s) from {result.DecryptedSessions} session(s):"
+);
+foreach (SessionResult session in result.Sessions)
+{
+    Console.WriteLine(
+        $"  Session {session.Index}: format v{session.FormatVersion}, "
+            + $"{session.DecryptedMessages} message(s), seal: {session.SealStatus}"
+    );
+}
+
+if (result.FailedHeaders > 0 || result.FailedMessages > 0)
+{
+    Console.WriteLine(
+        $"Failures: {result.FailedHeaders} header(s), {result.FailedMessages} message(s)."
+    );
+}
+
+Console.WriteLine("Decrypted log written to file-based-decrypted.log");
+return 0;

--- a/examples/Example.FileBasedApp/vLatestLog.cs
+++ b/examples/Example.FileBasedApp/vLatestLog.cs
@@ -1,0 +1,25 @@
+#:project ../../src/Serilog.Sinks.File.Encrypt/Serilog.Sinks.File.Encrypt.csproj
+
+using Serilog;
+using Serilog.Core;
+using Serilog.Sinks.File.Encrypt;
+
+string publicKey = File.ReadAllText("public_key.xml");
+
+Logger logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .WriteTo.File(
+        path: "file-based.log",
+        hooks: new EncryptHooks(publicKey, keyId: "file-based-key")
+    )
+    .CreateLogger();
+
+logger.Information("[vLatest] This is a test log message.");
+for (int i = 0; i < 10; i++)
+{
+    logger.Information("[vLatest] This is test log message number {LogNumber}.", i);
+}
+logger.Debug("[vLatest] This is a debug log message.");
+logger.Error("[vLatest] This is an error log message.");
+await logger.DisposeAsync();
+Console.WriteLine("[vLatest] Encrypted v2-format session appended to file-based.log");

--- a/examples/Example.WebApi/README.md
+++ b/examples/Example.WebApi/README.md
@@ -40,8 +40,9 @@ Generate a key pair using the CLI tool:
 # Install tool if needed
 dotnet tool install --global Serilog.Sinks.File.Encrypt.Cli
 
-# Generate key pair
-serilog-encrypt generate -o .
+# Generate key pair (XML keys are single-line, so they embed cleanly in JSON
+# configuration; --plaintext is required for the XML format)
+serilog-encrypt generate -o . --format Xml --plaintext
 ```
 
 Open the appsettings.json and configure the common Serilog settings by adding:
@@ -53,7 +54,7 @@ Open the appsettings.json and configure the common Serilog settings by adding:
 }
 ```
 
-Configure the Production environment to log only to an ecrypted file by creating an `appsettings.Production.json`:
+Configure the Production environment to log only to an encrypted file by creating an `appsettings.Production.json`:
 Take note of the `hooks` parameter in the File sink configuration, this points to the static method that sets up the encryption hook.
 Also note the `LogPublicKey` setting that contains the RSA public key used for encryption.  The static method will read this setting from configuration.
 ```json


### PR DESCRIPTION
Introduces a new `Example.FileBasedApp` demonstrating `Serilog.Sinks.File.Decrypt`'s ability to decrypt log files containing sessions written by both legacy v1 (from 4.x) and current v2 (from 6.x) on-disk formats. This showcases backward compatibility and single-pass decryption for mixed logs.

Updates `Example.Console` and `Example.WebApi` READMEs to explicitly specify `--format Xml --plaintext` for key generation commands, aligning instructions with the requirements of these examples and clarifying why these parameters are used.